### PR TITLE
fixed #11663 (daca: fetch basic analysis flags from server)

### DIFF
--- a/tools/donate-cpu.py
+++ b/tools/donate-cpu.py
@@ -174,7 +174,7 @@ while True:
             print('Stopping. Thank you!')
             sys.exit(0)
     try:
-        cppcheck_versions = lib.try_retry(lib.get_cppcheck_versions, max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
+        cppcheck_versions, build_opts, cppcheck_opts, timeout_s = lib.try_retry(lib.get_cppcheck_options, max_tries=3, sleep_duration=30.0, sleep_factor=1.0)
     except Exception as e:
         print('Failed to get cppcheck versions from server ({}), retry later'.format(e))
         sys.exit(1)
@@ -195,11 +195,11 @@ while True:
             print('Failed to update Cppcheck-{} ({}), retry later'.format(ver, e))
             sys.exit(1)
         if ver == 'main':
-            if (has_changes or not lib.has_binary(current_cppcheck_dir)) and not lib.compile_cppcheck(current_cppcheck_dir):
+            if (has_changes or not lib.has_binary(current_cppcheck_dir)) and not lib.compile_cppcheck(current_cppcheck_dir, build_opts):
                 print('Failed to compile Cppcheck-{}, retry later'.format(ver))
                 sys.exit(1)
         else:
-            if not lib.compile_version(current_cppcheck_dir):
+            if not lib.compile_version(current_cppcheck_dir, build_opts):
                 print('Failed to compile Cppcheck-{}, retry later'.format(ver))
                 sys.exit(1)
     if package_urls:
@@ -257,7 +257,7 @@ while True:
                     return None
 
             client_version_head = get_client_version_head()
-        c, errout, info, t, cppcheck_options, timing_info = lib.scan_package(tree_path, source_path, libraries, capture_callstack)
+        c, errout, info, t, cppcheck_options, timing_info = lib.scan_package(tree_path, source_path, libraries, cppcheck_opts, timeout_s, capture_callstack)
         if c < 0:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)

--- a/tools/test-my-pr.py
+++ b/tools/test-my-pr.py
@@ -95,12 +95,12 @@ if __name__ == "__main__":
         print('Failed to switch to common ancestor of your branch and main')
         sys.exit(1)
 
-    if not lib.compile_cppcheck(main_dir):
+    if not lib.compile_cppcheck(main_dir): # TODO
         print('Failed to compile main of Cppcheck')
         sys.exit(1)
 
     print('Testing your PR from directory: ' + your_repo_dir)
-    if not lib.compile_cppcheck(your_repo_dir):
+    if not lib.compile_cppcheck(your_repo_dir): # TODO
         print('Failed to compile your version of Cppcheck')
         sys.exit(1)
 
@@ -155,7 +155,7 @@ if __name__ == "__main__":
         your_timeout = False
 
         libraries = lib.library_includes.get_libraries(source_path)
-        c, errout, info, time_main, cppcheck_options, timing_info = lib.scan_package(main_dir, source_path, libraries)
+        c, errout, info, time_main, cppcheck_options, timing_info = lib.scan_package(main_dir, source_path, libraries) # TODO
         if c < 0:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)
@@ -168,7 +168,7 @@ if __name__ == "__main__":
                 main_crashed = True
         results_to_diff.append(errout)
 
-        c, errout, info, time_your, cppcheck_options, timing_info = lib.scan_package(your_repo_dir, source_path, libraries)
+        c, errout, info, time_your, cppcheck_options, timing_info = lib.scan_package(your_repo_dir, source_path, libraries) # TODO
         if c < 0:
             if c == -101 and 'error: could not find or open any of the paths given.' in errout:
                 # No sourcefile found (for example only headers present)


### PR DESCRIPTION
This adds a function to the daca server which provides the analysis and build options so they are no longer hard-coded in the clients and they are applied as soon a new server is deployed and we do not need to wait for all clients to be updated to get consistent data.