### PR TITLE
#12254: cppcheck.cfg can't be loaded from relative paths anymore

### DIFF
--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -76,10 +76,14 @@ def test_build_dir():
         args = f'--cppcheck-build-dir={tempdir} --enable=all --inline-suppr proj-inline-suppress/4.c'.split()
 
         ret, stdout, stderr = cppcheck(args)
+        for line in args:
+            print(line)
         assert ret == 0, stdout
         assert len(stderr) == 0
 
         ret, stdout, stderr = cppcheck(args)
+        for line in args:
+            print(line)
         assert ret == 0, stdout
         assert len(stderr) == 0
 

--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -75,15 +75,19 @@ def test_build_dir():
     with tempfile.TemporaryDirectory() as tempdir:
         args = f'--cppcheck-build-dir={tempdir} --enable=all --inline-suppr proj-inline-suppress/4.c'.split()
 
+        print('----------Argument for first run----------')
         ret, stdout, stderr = cppcheck(args)
         for line in args:
             print(line)
+        print('----------Argument for first run----------')
         assert ret == 0, stdout
         assert len(stderr) == 0
 
+        print('----------Argument for second run----------')
         ret, stdout, stderr = cppcheck(args)
         for line in args:
             print(line)
+        print('----------Argument for second run----------')
         assert ret == 0, stdout
         assert len(stderr) == 0
 

--- a/test/cli/test-inline-suppress.py
+++ b/test/cli/test-inline-suppress.py
@@ -75,19 +75,11 @@ def test_build_dir():
     with tempfile.TemporaryDirectory() as tempdir:
         args = f'--cppcheck-build-dir={tempdir} --enable=all --inline-suppr proj-inline-suppress/4.c'.split()
 
-        print('----------Argument for first run----------')
         ret, stdout, stderr = cppcheck(args)
-        for line in args:
-            print(line)
-        print('----------Argument for first run----------')
         assert ret == 0, stdout
         assert len(stderr) == 0
 
-        print('----------Argument for second run----------')
         ret, stdout, stderr = cppcheck(args)
-        for line in args:
-            print(line)
-        print('----------Argument for second run----------')
         assert ret == 0, stdout
         assert len(stderr) == 0
 

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -872,9 +872,9 @@ def test_premium_with_relative_path(tmpdir):
     cppcheck_exe = copy_and_prepare_cppcheck(tmpdir)
 
     # we should not recognize custom args without cppcheck.cfg
-    exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--premium=misra-c++-2008', test_file])
+    exitcode, stdout, stderr = cppcheck(['--premium=misra-c++-2008', test_file], None, True, cppcheck_exe)
     assert stderr == ''
-    #assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
+    assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
     assert exitcode == 1
 
     # adding cppcheck.cfg
@@ -888,13 +888,13 @@ def test_premium_with_relative_path(tmpdir):
                 """.replace('NAME', product_name))
 
     # should be fine now
-    exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--premium=misra-c++-2008', test_file])
+    exitcode, stdout, stderr = cppcheck(['--premium=misra-c++-2008', test_file], None, True, cppcheck_exe)
     assert stderr == ''
     assert f'Checking {test_file} ...' == stdout.strip()
     assert exitcode == 0
 
     # check the version it should be as in cppcheck.cfg
-    exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--version'])
+    exitcode, stdout, stderr = cppcheck(['--version'], None, True, cppcheck_exe)
     assert stdout.strip() == product_name
     assert stderr == ''
     assert exitcode == 0

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -878,28 +878,24 @@ def test_premium_with_relative_path(tmpdir):
     assert exitcode == 1
 
     # adding cppcheck.cfg
-    with open(tmpdir.join('cppcheck.cfg'), 'wt') as f:
+    with open(os.path.join(tmpdir, 'cppcheck.cfg'), 'wt') as f:
         f.write("""
                 {
                     "addons": [],
                     "productName": "NAME",
-                      "about": "Cppcheck Premium 1.2.3.4"
+                    "about": "Cppcheck Premium 1.2.3.4"
                 }
                 """.replace('NAME', product_name))
 
     # should be fine now
     exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--premium=misra-c++-2008', test_file])
     assert stderr == ''
-    out_lines = [
-        'Checking {} ...'.format(test_file)
-    ]
-    lines = stdout.splitlines()
-    assert lines == out_lines
+    assert f'Checking {test_file} ...' == stdout.strip()
     assert exitcode == 0
 
     # check the version it should be as in cppcheck.cfg
     exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--version'])
-    assert stdout == product_name + '\n'
+    assert stdout.strip() == product_name
     assert stderr == ''
     assert exitcode == 0
 

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -863,15 +863,9 @@ def test_build_dir_j_memleak(tmpdir): #12111
 
 
 def test_premium_with_relative_path(tmpdir):
-
-
-    test_file = os.path.join(tmpdir, 'test.c')
-    with open(test_file, 'wt'):
-        pass
-
     product_name = 'Cppcheck Premium ' + str(time.time())
 
-    test_cfg = tmpdir + 'cppcheck.cfg'
+    test_cfg = tmpdir.join('cppcheck.cfg')
     with open(test_cfg, 'wt') as f:
         f.write("""
                 {
@@ -881,15 +875,13 @@ def test_premium_with_relative_path(tmpdir):
                 }
                 """.replace('NAME', product_name))
 
-    #if os.path.isfile('cppcheck') :
-    #    os.chdir('test/cli')
-
     args = ['--premium=misra-c++-2008', 'test.c']
 
     exitcode, _, stderr = cppcheck(args, None, True, tmpdir)
     assert exitcode == 0
     assert stderr == ''
 
-    _, stdout, stderr = cppcheck(['--version'], None, True, tmpdir)
+    exitcode, stdout, stderr = cppcheck(['--version'], None, True, tmpdir)
     assert stdout == product_name + '\n'
     assert stderr == ''
+    assert exitcode == 0

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -4,6 +4,7 @@
 import os
 import sys
 import pytest
+import time
 
 from testutils import cppcheck, assert_cppcheck
 
@@ -859,3 +860,36 @@ def test_build_dir_j_memleak(tmpdir): #12111
     ]
 
     assert_cppcheck(args, ec_exp=0, err_exp=[], out_exp=out_lines)
+
+
+def test_premium_with_relative_path(tmpdir):
+
+
+    test_file = os.path.join(tmpdir, 'test.c')
+    with open(test_file, 'wt'):
+        pass
+
+    product_name = 'Cppcheck Premium ' + str(time.time())
+
+    test_cfg = tmpdir + 'cppcheck.cfg'
+    with open(test_cfg, 'wt') as f:
+        f.write("""
+                {
+                    "addons": [],
+                    "productName": "NAME",
+                      "about": "Cppcheck Premium 1.2.3.4"
+                }
+                """.replace('NAME', product_name))
+
+    #if os.path.isfile('cppcheck') :
+    #    os.chdir('test/cli')
+
+    args = ['--premium=misra-c++-2008', 'test.c']
+
+    exitcode, _, stderr = cppcheck(args, None, True, tmpdir)
+    assert exitcode == 0
+    assert stderr == ''
+
+    _, stdout, stderr = cppcheck(['--version'], None, True, tmpdir)
+    assert stdout == product_name + '\n'
+    assert stderr == ''

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -871,15 +871,14 @@ def test_premium_with_relative_path(tmpdir):
 
     cppcheck_exe = copy_and_prepare_cppcheck(tmpdir)
 
-    # we should not recognize custom args without cfg
+    # we should not recognize custom args without cppcheck.cfg
     exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--premium=misra-c++-2008', test_file])
     assert stderr == ''
     assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
     assert exitcode == 1
 
-    # adding cfg
-    test_cfg = tmpdir.join('cppcheck.cfg')
-    with open(test_cfg, 'wt') as f:
+    # adding cppcheck.cfg
+    with open(tmpdir.join('cppcheck.cfg'), 'wt') as f:
         f.write("""
                 {
                     "addons": [],
@@ -898,7 +897,7 @@ def test_premium_with_relative_path(tmpdir):
     assert lines == out_lines
     assert exitcode == 0
 
-    # check the version it should be as in cfg
+    # check the version it should be as in cppcheck.cfg
     exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--version'])
     assert stdout == product_name + '\n'
     assert stderr == ''

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -874,7 +874,7 @@ def test_premium_with_relative_path(tmpdir):
     # we should not recognize custom args without cppcheck.cfg
     exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--premium=misra-c++-2008', test_file])
     assert stderr == ''
-    assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
+    #assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
     assert exitcode == 1
 
     # adding cppcheck.cfg

--- a/test/cli/test-other.py
+++ b/test/cli/test-other.py
@@ -884,24 +884,26 @@ def test_premium_with_relative_path(tmpdir):
 
     cppcheck_exe = copy_and_prepare_cppcheck(tmpdir)
 
-    exitcode, _, stderr = cppcheck(args, None, True, cppcheck_exe)
+    args.insert(0, cppcheck_exe)
+
+    exitcode, _, stderr = cppcheck(args)
     assert stderr == ''
     assert exitcode == 0
 
 
-    exitcode, stdout, stderr = cppcheck(['--version'], None, True, cppcheck_exe)
+    exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--version'])
     assert stdout == product_name + '\n'
     assert stderr == ''
     assert exitcode == 0
 
     os.remove(test_cfg)
 
-    exitcode, stdout, stderr = cppcheck(['--premium=misra-c++-2008'], None, cppcheck_exe)
+    exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--premium=misra-c++-2008'])
     assert stderr == ''
     assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
     assert exitcode == 1
 
-    exitcode, stdout, stderr = cppcheck(['--version'], None, cppcheck_exe)
+    exitcode, stdout, stderr = cppcheck([cppcheck_exe, '--version'])
     assert stderr == ''
     assert stdout == 'Cppcheck 2.13 dev' + '\n'
     assert exitcode == 0
@@ -915,12 +917,12 @@ def test_premium_with_relative_path2(tmpdir):
 
     args = ['--premium=misra-c++-2008', test_file]
 
-    exitcode, stdout, stderr = cppcheck(args, None)
+    exitcode, stdout, stderr = cppcheck(args)
     assert stderr == ''
     assert stdout == 'cppcheck: error: unrecognized command line option: "--premium=misra-c++-2008".\n'
     assert exitcode == 1
 
-    exitcode, stdout, stderr = cppcheck(['--version'], None)
+    exitcode, stdout, stderr = cppcheck(['--version'])
     assert stdout == 'Cppcheck 2.13 dev' + '\n'
     assert stderr == ''
     assert exitcode == 0

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -43,10 +43,7 @@ def create_gui_project_file(project_file, root_path=None, import_project=None, p
     f.close()
 
 
-def __lookup_cppcheck_exe(cppcheck_exe_path=None):
-
-    if cppcheck_exe_path is not None:
-        return cppcheck_exe_path
+def __lookup_cppcheck_exe():
     
     # path the script is located in
     script_path = os.path.dirname(os.path.realpath(__file__))
@@ -88,20 +85,21 @@ def copy_and_prepare_cppcheck(tmpdir):
 
 # Run Cppcheck with args
 def cppcheck(args, env=None, remove_checkers_report=True):
-    exe = args[0]
+    args_to_use = args.copy()
+    exe = args_to_use[0]
     if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('/cppcheck.exe'):
         exe = __lookup_cppcheck_exe()
-        args.insert(0, exe)
+        args_to_use.insert(0, exe)
 
     assert exe is not None, 'no cppcheck binary found'
 
     print('----------inside cppcheck call----------')
-    for line in args:
+    for line in args_to_use:
         print(line)
     print('----------inside cppcheck call----------')
 
-    logging.info(args)
-    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+    logging.info(args_to_use)
+    p = subprocess.Popen(args_to_use, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     comm = p.communicate()
     stdout = comm[0].decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')
     stderr = comm[1].decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -78,8 +78,7 @@ def copy_and_prepare_cppcheck(tmpdir):
 
     #add minimum cfg
     test_cfg_folder = tmpdir.mkdir('cfg')
-    test_cfg = test_cfg_folder.join('std.cfg')
-    with open(test_cfg, 'wt') as f:
+    with open(test_cfg_folder.join('std.cfg'), 'wt') as f:
         f.write("""
                 <?xml version="1.0"?>
                 <def format="2"/>

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -43,12 +43,6 @@ def create_gui_project_file(project_file, root_path=None, import_project=None, p
     f.close()
 
 
-def __create_temporary_copy(tmpdir, temp_file_name):
-    temp_path = os.path.join(tmpdir, temp_file_name)
-    shutil.copy2(__lookup_cppcheck_exe(), temp_path)
-    return temp_path
-
-
 def __lookup_cppcheck_exe(cppcheck_exe_path=None):
 
     if cppcheck_exe_path is not None:
@@ -94,13 +88,16 @@ def copy_and_prepare_cppcheck(tmpdir):
 
 
 # Run Cppcheck with args
-def cppcheck(args, env=None, remove_checkers_report=True, cppcheck_exe_path=None):
-    exe = __lookup_cppcheck_exe(cppcheck_exe_path)
+def cppcheck(args, env=None, remove_checkers_report=True):
+    exe = args[0]
+    if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('/cppcheck.exe'):
+        exe = __lookup_cppcheck_exe()
+        args.insert(0, exe)
 
     assert exe is not None, 'no cppcheck binary found'
 
-    logging.info(exe + ' ' + ' '.join(args))
-    p = subprocess.Popen([exe] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+    logging.info(args)
+    p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     comm = p.communicate()
     stdout = comm[0].decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')
     stderr = comm[1].decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -44,14 +44,13 @@ def create_gui_project_file(project_file, root_path=None, import_project=None, p
     f.close()
 
 
-def create_temporary_copy(tmpdir, temp_file_name):
+def __create_temporary_copy(tmpdir, temp_file_name):
     temp_path = os.path.join(tmpdir, temp_file_name)
-    print (lookup_cppcheck_exe())
-    shutil.copy2(lookup_cppcheck_exe(), temp_path)
+    shutil.copy2(__lookup_cppcheck_exe(), temp_path)
     return temp_path
 
 
-def lookup_cppcheck_exe(script_path=None):
+def __lookup_cppcheck_exe(script_path=None):
     # path the script is located in
     if script_path == None:
         script_path = os.path.dirname(os.path.realpath(__file__))
@@ -84,27 +83,27 @@ def __copy_and_prepare_cppcheck(tmpdir):
     temp_file_name = "cppcheck"
     if sys.platform == "win32":
         temp_file_name += ".exe"
-    exe = create_temporary_copy(tmpdir, temp_file_name)
+    exe = __create_temporary_copy(tmpdir, temp_file_name)
 
     #add minimum cfg
-    test_cfg = tmpdir + 'cfg/std.cfg'
-    with open(test_cfg, 'wt') as f:
-        f.write("""
-                <?xml version="1.0"?>
-                <def format="2"/>
-                """)
+    if not os.path.exists(tmpdir + '/cfg'):
+        test_cfg_folder = tmpdir.mkdir('cfg')
+        test_cfg = test_cfg_folder.join('std.cfg')
+        if not os.path.exists(test_cfg):
+            with open(test_cfg, 'wt') as f:
+                f.write("""
+                        <?xml version="1.0"?>
+                        <def format="2"/>
+                        """)
     return exe
 
 
 # Run Cppcheck with args
 def cppcheck(args, env=None, remove_checkers_report=True, tmpdir=None):
     if tmpdir != None:
-        temp_file_name = "cppcheck"
-        if sys.platform == "win32":
-            temp_file_name += ".exe"
         exe = __copy_and_prepare_cppcheck(tmpdir)
     else:
-        exe = lookup_cppcheck_exe()
+        exe = __lookup_cppcheck_exe()
     assert exe is not None, 'no cppcheck binary found'
 
     logging.info(exe + ' ' + ' '.join(args))
@@ -139,3 +138,18 @@ def assert_cppcheck(args, ec_exp=None, out_exp=None, err_exp=None, env=None):
     if err_exp is not None:
         err_lines = stderr.splitlines()
         assert err_lines == err_exp, stderr
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import subprocess
-import tempfile
 import shutil
 
 # Create Cppcheck project file
@@ -80,10 +79,10 @@ def __lookup_cppcheck_exe(script_path=None):
 
 
 def __copy_and_prepare_cppcheck(tmpdir):
-    temp_file_name = "cppcheck"
+    file_name = "cppcheck"
     if sys.platform == "win32":
-        temp_file_name += ".exe"
-    exe = __create_temporary_copy(tmpdir, temp_file_name)
+        file_name += ".exe"
+    exe = __create_temporary_copy(tmpdir, file_name)
 
     #add minimum cfg
     if not os.path.exists(tmpdir + '/cfg'):
@@ -138,18 +137,3 @@ def assert_cppcheck(args, ec_exp=None, out_exp=None, err_exp=None, env=None):
     if err_exp is not None:
         err_lines = stderr.splitlines()
         assert err_lines == err_exp, stderr
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -87,16 +87,11 @@ def copy_and_prepare_cppcheck(tmpdir):
 def cppcheck(args, env=None, remove_checkers_report=True):
     args_to_use = args.copy()
     exe = args_to_use[0]
-    if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('/cppcheck.exe'):
+    if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('\cppcheck.exe'):
         exe = __lookup_cppcheck_exe()
         args_to_use.insert(0, exe)
 
     assert exe is not None, 'no cppcheck binary found'
-
-    print('----------inside cppcheck call----------')
-    for line in args_to_use:
-        print(line)
-    print('----------inside cppcheck call----------')
 
     logging.info(args_to_use)
     p = subprocess.Popen(args_to_use, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -84,17 +84,17 @@ def copy_and_prepare_cppcheck(tmpdir):
 
 
 # Run Cppcheck with args
-def cppcheck(args, env=None, remove_checkers_report=True):
-    args_to_use = args.copy()
-    exe = args_to_use[0]
-    if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('\\cppcheck.exe'):
+def cppcheck(args, env=None, remove_checkers_report=True, cppcheck_exe=None):
+    exe = None
+    if cppcheck_exe is not None:
+        exe = cppcheck_exe
+    else:
         exe = __lookup_cppcheck_exe()
-        args_to_use.insert(0, exe)
 
     assert exe is not None, 'no cppcheck binary found'
 
-    logging.info(args_to_use)
-    p = subprocess.Popen(args_to_use, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+    #logging.info(exe + ' ' + ' '.join(args))
+    p = subprocess.Popen([exe] + args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     comm = p.communicate()
     stdout = comm[0].decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')
     stderr = comm[1].decode(encoding='utf-8', errors='ignore').replace('\r\n', '\n')

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -87,7 +87,7 @@ def copy_and_prepare_cppcheck(tmpdir):
 def cppcheck(args, env=None, remove_checkers_report=True):
     args_to_use = args.copy()
     exe = args_to_use[0]
-    if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('\cppcheck.exe'):
+    if not exe == 'cppcheck' and not exe == 'cppcheck.exe' and not exe.endswith('/cppcheck') and not exe.endswith('\\cppcheck.exe'):
         exe = __lookup_cppcheck_exe()
         args_to_use.insert(0, exe)
 

--- a/test/cli/testutils.py
+++ b/test/cli/testutils.py
@@ -95,6 +95,11 @@ def cppcheck(args, env=None, remove_checkers_report=True):
 
     assert exe is not None, 'no cppcheck binary found'
 
+    print('----------inside cppcheck call----------')
+    for line in args:
+        print(line)
+    print('----------inside cppcheck call----------')
+
     logging.info(args)
     p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     comm = p.communicate()


### PR DESCRIPTION
fix python tests