### PR TITLE
fix #13378: syntax error for guessed macro value

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8729,10 +8729,16 @@ void Tokenizer::findGarbageCode() const
         if (Token::Match(tok, "%num%|%bool%|%char%|%str% %num%|%bool%|%char%|%str%") && !Token::Match(tok, "%str% %str%"))
             syntaxError(tok);
         if (Token::Match(tok, "%num%|%bool%|%char%|%str% {|(")) {
-            if (tok->strAt(1) == "(")
+            if (tok->strAt(1) == "(") {
+                if (tok->isExpandedMacro() && mSettings.userDefines.empty()) {
+                    throw InternalError(tok, "literal used as function. Macro '" + tok->getMacroName() +
+                                        "' expands to '" + tok->str() + +"'. Use -D" + tok->getMacroName() +
+                                        "=... to specify a value, or -U" + tok->getMacroName()
+                                        + " to undefine it.", InternalError::UNKNOWN_MACRO);
+                }
                 syntaxError(tok);
-            else if (!(tok->tokType() == Token::Type::eString && Token::simpleMatch(tok->tokAt(-1), "extern")) &&
-                     !(tok->tokType() == Token::Type::eBoolean && cpp && Token::simpleMatch(tok->tokAt(-1), "requires")))
+            } else if (!(tok->tokType() == Token::Type::eString && Token::simpleMatch(tok->tokAt(-1), "extern")) &&
+                       !(tok->tokType() == Token::Type::eBoolean && cpp && Token::simpleMatch(tok->tokAt(-1), "requires")))
                 syntaxError(tok);
         }
         if (Token::Match(tok, "( ) %num%|%bool%|%char%|%str%"))

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -8113,6 +8113,19 @@ void Tokenizer::unknownMacroError(const Token *tok1) const
     throw InternalError(tok1, "There is an unknown macro here somewhere. Configuration is required. If " + tok1->str() + " is a macro then please configure it.", InternalError::UNKNOWN_MACRO);
 }
 
+void Tokenizer::unknownMacroSyntaxError(const Token *tok, const std::string &description,
+                                        const Token *errTok, const std::string &code) const
+{
+    if (tok->isExpandedMacro() && mSettings.userDefines.empty()) {
+        throw InternalError(tok, description + ". Macro '" + tok->getMacroName() +
+                            "' expands to '" + tok->str() + +"'. Use -D" + tok->getMacroName() +
+                            "=... to specify a value, or -U" + tok->getMacroName()
+                            + " to undefine it.", InternalError::UNKNOWN_MACRO);
+    }
+    errTok = errTok ? errTok : tok;
+    syntaxError(errTok, code);
+}
+
 void Tokenizer::unhandled_macro_class_x_y(const Token *tok, const std::string& type, const std::string& x, const std::string& y, const std::string& bracket) const
 {
     reportError(tok,
@@ -8729,16 +8742,10 @@ void Tokenizer::findGarbageCode() const
         if (Token::Match(tok, "%num%|%bool%|%char%|%str% %num%|%bool%|%char%|%str%") && !Token::Match(tok, "%str% %str%"))
             syntaxError(tok);
         if (Token::Match(tok, "%num%|%bool%|%char%|%str% {|(")) {
-            if (tok->strAt(1) == "(") {
-                if (tok->isExpandedMacro() && mSettings.userDefines.empty()) {
-                    throw InternalError(tok, "literal used as function. Macro '" + tok->getMacroName() +
-                                        "' expands to '" + tok->str() + +"'. Use -D" + tok->getMacroName() +
-                                        "=... to specify a value, or -U" + tok->getMacroName()
-                                        + " to undefine it.", InternalError::UNKNOWN_MACRO);
-                }
-                syntaxError(tok);
-            } else if (!(tok->tokType() == Token::Type::eString && Token::simpleMatch(tok->tokAt(-1), "extern")) &&
-                       !(tok->tokType() == Token::Type::eBoolean && cpp && Token::simpleMatch(tok->tokAt(-1), "requires")))
+            if (tok->strAt(1) == "(")
+                unknownMacroSyntaxError(tok, "literal used as function");
+            else if (!(tok->tokType() == Token::Type::eString && Token::simpleMatch(tok->tokAt(-1), "extern")) &&
+                     !(tok->tokType() == Token::Type::eBoolean && cpp && Token::simpleMatch(tok->tokAt(-1), "requires")))
                 syntaxError(tok);
         }
         if (Token::Match(tok, "( ) %num%|%bool%|%char%|%str%"))
@@ -8774,7 +8781,7 @@ void Tokenizer::findGarbageCode() const
             !Token::Match(tok->previous(), "{|, . %name% =|.|[|{") &&
             !Token::Match(tok->previous(), ", . %name%")) {
             if (!Token::Match(tok->previous(), "%name%|)|]|>|}"))
-                syntaxError(tok, tok->strAt(-1) + " " + tok->str() + " " + tok->strAt(1));
+                unknownMacroSyntaxError(tok->previous(), "member access on literal", tok, tok->strAt(-1) + " " + tok->str() + " " + tok->strAt(1));
             if (!Token::Match(tok->next(), "%name%|*|~"))
                 syntaxError(tok, tok->strAt(-1) + " " + tok->str() + " " + tok->strAt(1));
         }

--- a/lib/tokenize.h
+++ b/lib/tokenize.h
@@ -385,6 +385,10 @@ public:
     /** Warn about unknown macro(s), configuration is recommended */
     NORETURN void unknownMacroError(const Token *tok1) const;
 
+    /** Syntax error that may be due to an unknown macro, for example START() where START=1 */
+    NORETURN void unknownMacroSyntaxError(const Token *tok, const std::string &description,
+                                          const Token *errTok = nullptr, const std::string &code = emptyString) const;
+
     void unhandledCharLiteral(const Token *tok, const std::string& msg) const;
 
 private:

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -63,6 +63,8 @@ private:
         TEST_CASE(getClangFlagsIncludeFile);
         TEST_CASE(invalidSyntaxUnknownMacro1); // #13378
         TEST_CASE(invalidSyntaxUnknownMacro2); // #13378
+        TEST_CASE(invalidSyntaxUnknownMacro3);
+        TEST_CASE(invalidSyntaxUnknownMacro4);
     }
 
     void getErrorMessages() const {
@@ -290,6 +292,46 @@ private:
         }), errorLogger.errmsgs.end());
         ASSERT_EQUALS(1, errorLogger.errmsgs.size());
         ASSERT_EQUALS("syntax error", errorLogger.errmsgs.cbegin()->shortMessage());
+        ASSERT_EQUALS("syntaxError", errorLogger.errmsgs.cbegin()->id);
+    }
+
+    void invalidSyntaxUnknownMacro3() {
+        ScopedFile file("test.c",
+                        "void foo(void) {\n"
+                        "#ifdef START\n"
+                        "    int k = START.f;\n"
+                        "#endif\n"
+                        "}\n");
+        ErrorLogger2 errorLogger;
+        CppCheck cppcheck(errorLogger, false, {});
+
+        ASSERT_EQUALS(1, cppcheck.check(FileWithDetails(file.path())));
+        errorLogger.errmsgs.erase(std::remove_if(errorLogger.errmsgs.begin(), errorLogger.errmsgs.end(), [](const ErrorMessage& msg) {
+            return msg.id == "logChecker";
+        }), errorLogger.errmsgs.end());
+        ASSERT_EQUALS(1, errorLogger.errmsgs.size());
+        ASSERT_EQUALS("member access on literal. Macro 'START' expands to '1'. Use -DSTART=... to specify a value, or -USTART to undefine it.",
+                      errorLogger.errmsgs.cbegin()->shortMessage());
+        ASSERT_EQUALS("unknownMacro", errorLogger.errmsgs.cbegin()->id);
+    }
+
+    void invalidSyntaxUnknownMacro4() {
+        ScopedFile file("test.c",
+                        "void foo(void) {\n"
+                        "#ifdef START\n"
+                        "    int k = START.f;\n"
+                        "#endif\n"
+                        "}\n");
+        ErrorLogger2 errorLogger;
+        CppCheck cppcheck(errorLogger, false, {});
+        cppcheck.settings().userDefines = "START=1";     // cppcheck -DSTART ...
+
+        ASSERT_EQUALS(1, cppcheck.check(FileWithDetails(file.path())));
+        errorLogger.errmsgs.erase(std::remove_if(errorLogger.errmsgs.begin(), errorLogger.errmsgs.end(), [](const ErrorMessage& msg) {
+            return msg.id == "logChecker";
+        }), errorLogger.errmsgs.end());
+        ASSERT_EQUALS(1, errorLogger.errmsgs.size());
+        ASSERT_EQUALS("syntax error: 1 . f", errorLogger.errmsgs.cbegin()->shortMessage());
         ASSERT_EQUALS("syntaxError", errorLogger.errmsgs.cbegin()->id);
     }
 

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -264,8 +264,8 @@ private:
         CppCheck cppcheck(errorLogger, false, {});
 
         ASSERT_EQUALS(1, cppcheck.check(FileWithDetails(file.path())));
-        errorLogger.errmsgs.erase(std::remove_if(errorLogger.errmsgs.begin(), errorLogger.errmsgs.end(), [](const ErrorMessage& errmsg) {
-            return errmsg.id == "logChecker";
+        errorLogger.errmsgs.erase(std::remove_if(errorLogger.errmsgs.begin(), errorLogger.errmsgs.end(), [](const ErrorMessage& msg) {
+            return msg.id == "logChecker";
         }), errorLogger.errmsgs.end());
         ASSERT_EQUALS(1, errorLogger.errmsgs.size());
         ASSERT_EQUALS("literal used as function. Macro 'START' expands to '1'. Use -DSTART=... to specify a value, or -USTART to undefine it.",
@@ -285,8 +285,8 @@ private:
         cppcheck.settings().userDefines = "START=1"; // cppcheck -DSTART ...
 
         ASSERT_EQUALS(1, cppcheck.check(FileWithDetails(file.path())));
-        errorLogger.errmsgs.erase(std::remove_if(errorLogger.errmsgs.begin(), errorLogger.errmsgs.end(), [](const ErrorMessage& errmsg) {
-            return errmsg.id == "logChecker";
+        errorLogger.errmsgs.erase(std::remove_if(errorLogger.errmsgs.begin(), errorLogger.errmsgs.end(), [](const ErrorMessage& msg) {
+            return msg.id == "logChecker";
         }), errorLogger.errmsgs.end());
         ASSERT_EQUALS(1, errorLogger.errmsgs.size());
         ASSERT_EQUALS("syntax error", errorLogger.errmsgs.cbegin()->shortMessage());


### PR DESCRIPTION
Example output:

```
Checking tickets/13378.c ...
Checking tickets/13378.c: START...
tickets/13378.c:3:5: error: literal used as function. Macro 'START' expands to '1'. Use -DSTART=... to specify a value, or -USTART to undefine it. [unknownMacro]
    START();
    ^
```

With `-DSTART` the syntax error remains:
```
Checking tickets/13378.c ...
Checking tickets/13378.c: START=1...
tickets/13378.c:3:5: error: syntax error [syntaxError]
    START();
    ^
```