### PR TITLE
Fix #14113 (Slow analysis: microchip xc16 code)

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Self check (unusedFunction / no test / no gui)
         run: |
-          supprs="--suppress=unusedFunction:lib/errorlogger.h:197 --suppress=unusedFunction:lib/importproject.cpp:1671 --suppress=unusedFunction:lib/importproject.cpp:1695"
+          supprs="--suppress=unusedFunction:lib/errorlogger.h:198 --suppress=unusedFunction:lib/importproject.cpp:1671 --suppress=unusedFunction:lib/importproject.cpp:1695"
           ./cppcheck -q --template=selfcheck --error-exitcode=1 --library=cppcheck-lib -D__CPPCHECK__ -D__GNUC__ --enable=unusedFunction,information --exception-handling -rp=. --project=cmake.output.notest_nogui/compile_commands.json --suppressions-list=.selfcheck_unused_suppressions --inline-suppr $supprs
         env:
           DISABLE_VALUEFLOW: 1

--- a/.selfcheck_suppressions
+++ b/.selfcheck_suppressions
@@ -62,6 +62,8 @@ templateInstantiation:test/testutils.cpp
 
 naming-varname:externals/simplecpp/simplecpp.h
 naming-privateMemberVariable:externals/simplecpp/simplecpp.h
+# false positive; lambda captures its owner
+danglingLifetime:externals/simplecpp/simplecpp.h:505
 
 # TODO: these warnings need to be addressed upstream
 uninitMemberVar:externals/tinyxml2/tinyxml2.h

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -100,7 +100,7 @@ public:
         closePlist();
     }
 
-    void addRemarkComments(std::vector<RemarkComment> remarkComments)
+    void addRemarkComments(const std::vector<RemarkComment> &remarkComments)
     {
         mRemarkComments.insert(mRemarkComments.end(), remarkComments.begin(), remarkComments.end());
     }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -61,6 +61,7 @@
 #include <exception> // IWYU pragma: keep
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <new>
 #include <set>
@@ -1049,8 +1050,10 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         std::set<std::string> configDefines = { "__cplusplus" };
 
         // Insert library defines
-        for (const auto &define : mSettings.library.defines())
-            configDefines.insert(define.substr(0, define.find_first_of("( ")));
+        std::transform(mSettings.library.defines().begin(),
+                       mSettings.library.defines().end(),
+                       std::inserter(configDefines, configDefines.end()),
+                       [](const auto &define) { return define.substr(0, define.find_first_of("( ")); });
 
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             // Do preprocessing on included file

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -100,9 +100,9 @@ public:
         closePlist();
     }
 
-    void setRemarkComments(std::vector<RemarkComment> remarkComments)
+    std::vector<RemarkComment>& remarkComments()
     {
-        mRemarkComments = std::move(remarkComments);
+        return mRemarkComments;
     }
 
     void setLocationMacros(const Token* startTok, const std::vector<std::string>& files)
@@ -124,17 +124,25 @@ public:
         mErrorList.clear();
     }
 
-    void openPlist(const std::string& filename, const std::vector<std::string>& files)
+    void openPlist(const std::string& filename)
     {
         mPlistFile.open(filename);
-        mPlistFile << ErrorLogger::plistHeader(version(), files);
+        mPlistFile << ErrorLogger::plistHeader(version());
+    }
+
+    void setPlistFilenames(std::vector<std::string> files)
+    {
+        if (mPlistFile.is_open()) {
+            mPlistFilenames = std::move(files);
+        }
     }
 
     void closePlist()
     {
         if (mPlistFile.is_open()) {
-            mPlistFile << ErrorLogger::plistFooter();
+            mPlistFile << ErrorLogger::plistFooter(mPlistFilenames);
             mPlistFile.close();
+            mPlistFilenames.clear();
         }
     }
 
@@ -282,6 +290,7 @@ private:
     std::map<Location, std::set<std::string>> mLocationMacros; // What macros are used on a location?
 
     std::ofstream mPlistFile;
+    std::vector<std::string> mPlistFilenames;
 
     unsigned int mExitCode{};
 
@@ -898,7 +907,7 @@ unsigned int CppCheck::checkFile(const FileWithDetails& file, const std::string 
     return checkInternal(file, cfgname, f);
 }
 
-void CppCheck::checkPlistOutput(const FileWithDetails& file, const std::vector<std::string>& files)
+void CppCheck::checkPlistOutput(const FileWithDetails& file)
 {
     if (!mSettings.plistOutput.empty()) {
         const bool slashFound = file.spath().find('/') != std::string::npos;
@@ -909,7 +918,7 @@ void CppCheck::checkPlistOutput(const FileWithDetails& file, const std::vector<s
         // the hash is added to handle when files in different folders have the same name
         const std::size_t fileNameHash = std::hash<std::string> {}(file.spath());
         filename = mSettings.plistOutput + noSuffixFilename + "_" + std::to_string(fileNameHash) + ".plist";
-        mLogger->openPlist(filename, files);
+        mLogger->openPlist(filename);
     }
 }
 
@@ -1000,24 +1009,16 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         if (preprocessor.reportOutput(outputList, true))
             return mLogger->exitcode();
 
-        if (!preprocessor.loadFiles(files))
-            return mLogger->exitcode();
+        checkPlistOutput(file);
 
-        checkPlistOutput(file, files);
-
-        std::string dumpProlog;
+        std::string dumpFooter;
         if (mSettings.dump || !mSettings.addons.empty()) {
-            dumpProlog += getDumpFileContentsRawTokens(files, tokens1);
+            dumpFooter += getDumpFileContentsRawTokensFooter(tokens1);
         }
 
         // Parse comments and then remove them
-        mLogger->setRemarkComments(preprocessor.getRemarkComments());
+        preprocessor.addRemarkComments(mLogger->remarkComments());
         preprocessor.inlineSuppressions(mSuppressions.nomsg);
-        if (mSettings.dump || !mSettings.addons.empty()) {
-            std::ostringstream oss;
-            mSuppressions.nomsg.dump(oss);
-            dumpProlog += oss.str();
-        }
         preprocessor.removeComments();
 
         if (!mSettings.buildDir.empty()) {
@@ -1040,19 +1041,48 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         }
 
         // Get directives
-        std::list<Directive> directives = preprocessor.createDirectives();
+        std::list<Directive> directives;
+        preprocessor.createDirectives(directives);
         preprocessor.simplifyPragmaAsm();
+
+        std::set<std::string> configurations;
+        std::set<std::string> configDefines = { "__cplusplus" };
+
+        // Insert library defines
+        for (const auto &define : mSettings.library.defines()) {
+            const std::string::size_type paren = define.find("(");
+            const std::string::size_type space = define.find(" ");
+            std::string::size_type end = space;
+
+            if (paren != std::string::npos && paren < space)
+                end = paren;
+
+            configDefines.insert(define.substr(0, end));
+        }
+
+        preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
+            // Do preprocessing on included file
+            preprocessor.addRemarkComments(data.tokens, mLogger->remarkComments());
+            preprocessor.inlineSuppressions(data.tokens, mSuppressions.nomsg);
+            Preprocessor::removeComments(data.tokens);
+            Preprocessor::createDirectives(data.tokens, directives);
+            Preprocessor::simplifyPragmaAsm(data.tokens);
+            // Discover new configurations from included file
+            if (configurations.size() < maxConfigs)
+                preprocessor.getConfigs(data.filename, data.tokens, configDefines, configurations);
+        });
 
         preprocessor.setPlatformInfo();
 
         // Get configurations..
-        std::set<std::string> configurations;
         if (maxConfigs > 1) {
             Timer::run("Preprocessor::getConfigs", mTimerResults, [&]() {
-                configurations = preprocessor.getConfigs();
+                configurations = { "" };
+                preprocessor.getConfigs(configDefines, configurations);
+                preprocessor.loadFiles(files);
             });
         } else {
-            configurations.insert(mSettings.userDefines);
+            configurations = { mSettings.userDefines };
         }
 
         if (mSettings.checkConfiguration) {
@@ -1089,7 +1119,6 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         createDumpFile(mSettings, file, fdump, dumpFile);
         if (fdump.is_open()) {
             fdump << getLibraryDumpData();
-            fdump << dumpProlog;
             if (!mSettings.dump)
                 filesDeleter.addFile(dumpFile);
         }
@@ -1259,10 +1288,18 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         }
 
         // TODO: will not be closed if we encountered an exception
-        // dumped all configs, close root </dumps> element now
         if (fdump.is_open()) {
+            // dump all filenames, raw tokens, suppressions
+            std::string dumpHeader = getDumpFileContentsRawTokensHeader(files);
+            fdump << getDumpFileContentsRawTokens(dumpHeader, dumpFooter);
+            mSuppressions.nomsg.dump(fdump);
+            // dumped all configs, close root </dumps> element now
             fdump << "</dumps>" << std::endl;
             fdump.close();
+        }
+
+        if (!mSettings.plistOutput.empty()) {
+            mLogger->setPlistFilenames(std::move(files));
         }
 
         executeAddons(dumpFile, file);
@@ -1892,9 +1929,26 @@ bool CppCheck::isPremiumCodingStandardId(const std::string& id) const {
     return false;
 }
 
-std::string CppCheck::getDumpFileContentsRawTokens(const std::vector<std::string>& files, const simplecpp::TokenList& tokens1) const {
+std::string CppCheck::getDumpFileContentsRawTokens(const std::vector<std::string>& files, const simplecpp::TokenList& tokens1) const
+{
+    std::string header = getDumpFileContentsRawTokensHeader(files);
+    std::string footer = getDumpFileContentsRawTokensFooter(tokens1);
+    return getDumpFileContentsRawTokens(header, footer);
+}
+
+std::string CppCheck::getDumpFileContentsRawTokens(const std::string& header, const std::string& footer)
+{
     std::string dumpProlog;
     dumpProlog += "  <rawtokens>\n";
+    dumpProlog += header;
+    dumpProlog += footer;
+    dumpProlog += "  </rawtokens>\n";
+    return dumpProlog;
+}
+
+std::string CppCheck::getDumpFileContentsRawTokensHeader(const std::vector<std::string>& files) const
+{
+    std::string dumpProlog;
     for (unsigned int i = 0; i < files.size(); ++i) {
         dumpProlog += "    <file index=\"";
         dumpProlog += std::to_string(i);
@@ -1902,6 +1956,12 @@ std::string CppCheck::getDumpFileContentsRawTokens(const std::vector<std::string
         dumpProlog += ErrorLogger::toxml(Path::getRelativePath(files[i], mSettings.basePaths));
         dumpProlog += "\"/>\n";
     }
+    return dumpProlog;
+}
+
+std::string CppCheck::getDumpFileContentsRawTokensFooter(const simplecpp::TokenList& tokens1)
+{
+    std::string dumpProlog;
     for (const simplecpp::Token *tok = tokens1.cfront(); tok; tok = tok->next) {
         dumpProlog += "    <tok ";
 
@@ -1913,7 +1973,7 @@ std::string CppCheck::getDumpFileContentsRawTokens(const std::vector<std::string
         dumpProlog += std::to_string(tok->location.line);
         dumpProlog += "\" ";
 
-        dumpProlog +="column=\"";
+        dumpProlog += "column=\"";
         dumpProlog += std::to_string(tok->location.col);
         dumpProlog += "\" ";
 
@@ -1923,6 +1983,5 @@ std::string CppCheck::getDumpFileContentsRawTokens(const std::vector<std::string
 
         dumpProlog += "/>\n";
     }
-    dumpProlog += "  </rawtokens>\n";
     return dumpProlog;
 }

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1049,16 +1049,8 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         std::set<std::string> configDefines = { "__cplusplus" };
 
         // Insert library defines
-        for (const auto &define : mSettings.library.defines()) {
-            const std::string::size_type paren = define.find("(");
-            const std::string::size_type space = define.find(" ");
-            std::string::size_type end = space;
-
-            if (paren != std::string::npos && paren < space)
-                end = paren;
-
-            configDefines.insert(define.substr(0, end));
-        }
+        for (const auto &define : mSettings.library.defines())
+            configDefines.insert(define.substr(0, define.find_first_of("( ")));
 
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             // Do preprocessing on included file

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -100,9 +100,9 @@ public:
         closePlist();
     }
 
-    std::vector<RemarkComment>& remarkComments()
+    void addRemarkComments(std::vector<RemarkComment> remarkComments)
     {
-        return mRemarkComments;
+        mRemarkComments.insert(mRemarkComments.end(), remarkComments.begin(), remarkComments.end());
     }
 
     void setLocationMacros(const Token* startTok, const std::vector<std::string>& files)
@@ -1017,7 +1017,7 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         }
 
         // Parse comments and then remove them
-        preprocessor.addRemarkComments(mLogger->remarkComments());
+        mLogger->addRemarkComments(preprocessor.getRemarkComments());
         preprocessor.inlineSuppressions(mSuppressions.nomsg);
         preprocessor.removeComments();
 
@@ -1062,7 +1062,7 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
 
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             // Do preprocessing on included file
-            preprocessor.addRemarkComments(data.tokens, mLogger->remarkComments());
+            mLogger->addRemarkComments(preprocessor.getRemarkComments(data.tokens));
             preprocessor.inlineSuppressions(data.tokens, mSuppressions.nomsg);
             Preprocessor::removeComments(data.tokens);
             Preprocessor::createDirectives(data.tokens, directives);

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1050,10 +1050,13 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         std::set<std::string> configDefines = { "__cplusplus" };
 
         // Insert library defines
+        const auto getDefineName = [](const std::string &defineString) {
+            return defineString.substr(0, defineString.find_first_of("( "));
+        };
         std::transform(mSettings.library.defines().begin(),
                        mSettings.library.defines().end(),
                        std::inserter(configDefines, configDefines.end()),
-                       [](const std::string &define) { return define.substr(0, define.find_first_of("( ")); });
+                       getDefineName);
 
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             // Do preprocessing on included file

--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -1053,7 +1053,7 @@ unsigned int CppCheck::checkInternal(const FileWithDetails& file, const std::str
         std::transform(mSettings.library.defines().begin(),
                        mSettings.library.defines().end(),
                        std::inserter(configDefines, configDefines.end()),
-                       [](const auto &define) { return define.substr(0, define.find_first_of("( ")); });
+                       [](const std::string &define) { return define.substr(0, define.find_first_of("( ")); });
 
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             // Do preprocessing on included file

--- a/lib/cppcheck.h
+++ b/lib/cppcheck.h
@@ -153,6 +153,9 @@ private:
      * @brief Get dumpfile <rawtokens> contents, this is only public for testing purposes
      */
     std::string getDumpFileContentsRawTokens(const std::vector<std::string>& files, const simplecpp::TokenList& tokens1) const;
+    static std::string getDumpFileContentsRawTokens(const std::string& header, const std::string& footer);
+    std::string getDumpFileContentsRawTokensHeader(const std::vector<std::string>& files) const;
+    static std::string getDumpFileContentsRawTokensFooter(const simplecpp::TokenList& tokens1);
 
     std::string getLibraryDumpData() const;
 
@@ -183,7 +186,7 @@ private:
      */
     unsigned int checkFile(const FileWithDetails& file, const std::string &cfgname);
 
-    void checkPlistOutput(const FileWithDetails& file, const std::vector<std::string>& files);
+    void checkPlistOutput(const FileWithDetails& file);
 
     /**
      * @brief Check a file using buffer

--- a/lib/errorlogger.cpp
+++ b/lib/errorlogger.cpp
@@ -821,7 +821,7 @@ std::string ErrorLogger::toxml(const std::string &str)
     return xml;
 }
 
-std::string ErrorLogger::plistHeader(const std::string &version, const std::vector<std::string> &files)
+std::string ErrorLogger::plistHeader(const std::string &version)
 {
     std::ostringstream ostr;
     ostr << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n"
@@ -829,12 +829,7 @@ std::string ErrorLogger::plistHeader(const std::string &version, const std::vect
          << "<plist version=\"1.0\">\r\n"
          << "<dict>\r\n"
          << " <key>clang_version</key>\r\n"
-         << "<string>cppcheck version " << version << "</string>\r\n"
-         << " <key>files</key>\r\n"
-         << " <array>\r\n";
-    for (const std::string & file : files)
-        ostr << "  <string>" << ErrorLogger::toxml(file) << "</string>\r\n";
-    ostr << " </array>\r\n"
+         << " <string>cppcheck version " << version << "</string>\r\n"
          << " <key>diagnostics</key>\r\n"
          << " <array>\r\n";
     return ostr.str();

--- a/lib/errorlogger.h
+++ b/lib/errorlogger.h
@@ -28,6 +28,7 @@
 #include <ctime>
 #include <list>
 #include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -271,12 +272,19 @@ public:
      */
     static std::string toxml(const std::string &str);
 
-    static std::string plistHeader(const std::string &version, const std::vector<std::string> &files);
+    static std::string plistHeader(const std::string &version);
     static std::string plistData(const ErrorMessage &msg);
-    static const char *plistFooter() {
-        return " </array>\r\n"
-               "</dict>\r\n"
-               "</plist>";
+    static std::string plistFooter(const std::vector<std::string>& files) {
+        std::ostringstream ostr;
+        ostr << " </array>\r\n"
+             << " <key>files</key>\r\n"
+             << " <array>\r\n";
+        for (const std::string& file : files)
+            ostr << "  <string>" << ErrorLogger::toxml(file) << "</string>\r\n";
+        ostr << " </array>\r\n"
+             << "</dict>\r\n"
+             << "</plist>";
+        return ostr.str();
     }
 
     static bool isCriticalErrorId(const std::string& id) {

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -336,20 +336,23 @@ static void addInlineSuppressions(const simplecpp::TokenList &tokens, const Sett
     }
 }
 
-void Preprocessor::inlineSuppressions(SuppressionList &suppressions)
+void Preprocessor::inlineSuppressions(SuppressionList &suppressions) const
+{
+    inlineSuppressions(mTokens, suppressions);
+}
+
+void Preprocessor::inlineSuppressions(const simplecpp::TokenList &tokens, SuppressionList &suppressions) const
 {
     if (!mSettings.inlineSuppressions)
         return;
     std::list<BadInlineSuppression> err;
-    ::addInlineSuppressions(mTokens, mSettings, suppressions, err);
-    for (const auto &filedata : mFileCache) {
-        ::addInlineSuppressions(filedata->tokens, mSettings, suppressions, err);
-    }
+    ::addInlineSuppressions(tokens, mSettings, suppressions, err);
     for (const BadInlineSuppression &bad : err) {
         invalidSuppression(bad.location, bad.errmsg);
     }
 }
 
+// cppcheck-suppress unusedFunction - only used in tests
 std::vector<RemarkComment> Preprocessor::getRemarkComments() const
 {
     std::vector<RemarkComment> ret;
@@ -360,43 +363,33 @@ std::vector<RemarkComment> Preprocessor::getRemarkComments() const
     return ret;
 }
 
-std::list<Directive> Preprocessor::createDirectives() const
+void Preprocessor::createDirectives(std::list<Directive> &directives) const
 {
-    // directive list..
-    std::list<Directive> directives;
+    createDirectives(mTokens, directives);
+}
 
-    std::vector<const simplecpp::TokenList *> list;
-    list.reserve(1U + mFileCache.size());
-    list.push_back(&mTokens);
-    std::transform(mFileCache.cbegin(), mFileCache.cend(), std::back_inserter(list),
-                   [](const std::unique_ptr<simplecpp::FileData> &filedata) {
-        return &filedata->tokens;
-    });
-
-    for (const simplecpp::TokenList *tokenList : list) {
-        for (const simplecpp::Token *tok = tokenList->cfront(); tok; tok = tok->next) {
-            if ((tok->op != '#') || (tok->previous && tok->previous->location.line == tok->location.line))
+void Preprocessor::createDirectives(const simplecpp::TokenList &tokens, std::list<Directive> &directives)
+{
+    for (const simplecpp::Token *tok = tokens.cfront(); tok; tok = tok->next) {
+        if ((tok->op != '#') || (tok->previous && tok->previous->location.line == tok->location.line))
+            continue;
+        if (tok->next && tok->next->str() == "endfile")
+            continue;
+        Directive directive(tokens, tok->location, "");
+        for (const simplecpp::Token *tok2 = tok; tok2 && tok2->location.line == directive.linenr; tok2 = tok2->next) {
+            if (tok2->comment)
                 continue;
-            if (tok->next && tok->next->str() == "endfile")
-                continue;
-            Directive directive(mTokens, tok->location, "");
-            for (const simplecpp::Token *tok2 = tok; tok2 && tok2->location.line == directive.linenr; tok2 = tok2->next) {
-                if (tok2->comment)
-                    continue;
-                if (!directive.str.empty() && (tok2->location.col > tok2->previous->location.col + tok2->previous->str().size()))
-                    directive.str += ' ';
-                if (directive.str == "#" && tok2->str() == "file")
-                    directive.str += "include";
-                else
-                    directive.str += tok2->str();
+            if (!directive.str.empty() && (tok2->location.col > tok2->previous->location.col + tok2->previous->str().size()))
+                directive.str += ' ';
+            if (directive.str == "#" && tok2->str() == "file")
+                directive.str += "include";
+            else
+                directive.str += tok2->str();
 
-                directive.strTokens.emplace_back(*tok2);
-            }
-            directives.push_back(std::move(directive));
+            directive.strTokens.emplace_back(*tok2);
         }
+        directives.push_back(std::move(directive));
     }
-
-    return directives;
 }
 
 static std::string readcondition(const simplecpp::Token *iftok, const std::set<std::string> &defined, const std::set<std::string> &undefined)
@@ -769,36 +762,21 @@ static void getConfigs(const simplecpp::TokenList &tokens, std::set<std::string>
         ret.insert(std::move(elseError));
 }
 
-
-std::set<std::string> Preprocessor::getConfigs() const
+void Preprocessor::getConfigs(std::set<std::string> &defined, std::set<std::string> &configs) const
 {
-    std::set<std::string> ret = { "" };
     if (!mTokens.cfront())
-        return ret;
+        return;
 
-    std::set<std::string> defined = { "__cplusplus" };
+    ::getConfigs(mTokens, defined, mSettings.userDefines, mSettings.userUndefs, configs);
+}
 
-    // Insert library defines
-    for (const auto &define : mSettings.library.defines()) {
+void Preprocessor::getConfigs(const std::string &filename, const simplecpp::TokenList &tokens, std::set<std::string> &defined, std::set<std::string> &configs) const
+{
+    if (!tokens.cfront())
+        return;
 
-        const std::string::size_type paren = define.find("(");
-        const std::string::size_type space = define.find(" ");
-        std::string::size_type end = space;
-
-        if (paren != std::string::npos && paren < space)
-            end = paren;
-
-        defined.insert(define.substr(0, end));
-    }
-
-    ::getConfigs(mTokens, defined, mSettings.userDefines, mSettings.userUndefs, ret);
-
-    for (const auto &filedata : mFileCache) {
-        if (!mSettings.configurationExcluded(filedata->filename))
-            ::getConfigs(filedata->tokens, defined, mSettings.userDefines, mSettings.userUndefs, ret);
-    }
-
-    return ret;
+    if (!mSettings.configurationExcluded(filename))
+        ::getConfigs(tokens, defined, mSettings.userDefines, mSettings.userUndefs, configs);
 }
 
 static void splitcfg(const std::string &cfgStr, std::list<std::string> &defines, const std::string &defaultValue)
@@ -871,16 +849,18 @@ bool Preprocessor::loadFiles(std::vector<std::string> &files)
     const simplecpp::DUI dui = createDUI(mSettings, "", mLang);
 
     simplecpp::OutputList outputList;
-    mFileCache = simplecpp::load(mTokens, files, dui, &outputList);
+    mFileCache = simplecpp::load(mTokens, files, dui, &outputList, std::move(mFileCache));
     return !handleErrors(outputList);
 }
 
 void Preprocessor::removeComments()
 {
-    mTokens.removeComments();
-    for (const auto &filedata : mFileCache) {
-        filedata->tokens.removeComments();
-    }
+    removeComments(mTokens);
+}
+
+void Preprocessor::removeComments(simplecpp::TokenList &tokens)
+{
+    tokens.removeComments();
 }
 
 void Preprocessor::setPlatformInfo()
@@ -1016,12 +996,12 @@ static std::string simplecppErrToId(simplecpp::Output::Type type)
     cppcheck::unreachable();
 }
 
-void Preprocessor::error(const simplecpp::Location& loc, const std::string &msg, simplecpp::Output::Type type)
+void Preprocessor::error(const simplecpp::Location& loc, const std::string &msg, simplecpp::Output::Type type) const
 {
     error(loc, msg, simplecppErrToId(type));
 }
 
-void Preprocessor::error(const simplecpp::Location& loc, const std::string &msg, const std::string& id)
+void Preprocessor::error(const simplecpp::Location& loc, const std::string &msg, const std::string& id) const
 {
     std::list<ErrorMessage::FileLocation> locationList;
     if (!mTokens.file(loc).empty()) {
@@ -1059,7 +1039,7 @@ void Preprocessor::missingInclude(const simplecpp::Location& loc, const std::str
     mErrorLogger.reportErr(errmsg);
 }
 
-void Preprocessor::invalidSuppression(const simplecpp::Location& loc, const std::string &msg)
+void Preprocessor::invalidSuppression(const simplecpp::Location& loc, const std::string &msg) const
 {
     error(loc, msg, "invalidSuppression");
 }
@@ -1143,13 +1123,10 @@ std::size_t Preprocessor::calculateHash(const std::string &toolinfo) const
 
 void Preprocessor::simplifyPragmaAsm()
 {
-    Preprocessor::simplifyPragmaAsmPrivate(mTokens);
-    for (const auto &filedata : mFileCache) {
-        Preprocessor::simplifyPragmaAsmPrivate(filedata->tokens);
-    }
+    simplifyPragmaAsm(mTokens);
 }
 
-void Preprocessor::simplifyPragmaAsmPrivate(simplecpp::TokenList &tokenList)
+void Preprocessor::simplifyPragmaAsm(simplecpp::TokenList &tokenList)
 {
     // assembler code..
     for (simplecpp::Token *tok = tokenList.front(); tok; tok = tok->next) {
@@ -1196,6 +1173,10 @@ void Preprocessor::simplifyPragmaAsmPrivate(simplecpp::TokenList &tokenList)
     }
 }
 
+void Preprocessor::addRemarkComments(std::vector<RemarkComment>& remarkComments) const
+{
+    addRemarkComments(mTokens, remarkComments);
+}
 
 void Preprocessor::addRemarkComments(const simplecpp::TokenList &tokens, std::vector<RemarkComment> &remarkComments) const
 {

--- a/lib/preprocessor.cpp
+++ b/lib/preprocessor.cpp
@@ -352,17 +352,6 @@ void Preprocessor::inlineSuppressions(const simplecpp::TokenList &tokens, Suppre
     }
 }
 
-// cppcheck-suppress unusedFunction - only used in tests
-std::vector<RemarkComment> Preprocessor::getRemarkComments() const
-{
-    std::vector<RemarkComment> ret;
-    addRemarkComments(mTokens, ret);
-    for (const auto &filedata : mFileCache) {
-        addRemarkComments(filedata->tokens, ret);
-    }
-    return ret;
-}
-
 void Preprocessor::createDirectives(std::list<Directive> &directives) const
 {
     createDirectives(mTokens, directives);
@@ -1173,13 +1162,15 @@ void Preprocessor::simplifyPragmaAsm(simplecpp::TokenList &tokenList)
     }
 }
 
-void Preprocessor::addRemarkComments(std::vector<RemarkComment>& remarkComments) const
+std::vector<RemarkComment> Preprocessor::getRemarkComments() const
 {
-    addRemarkComments(mTokens, remarkComments);
+    return getRemarkComments(mTokens);
 }
 
-void Preprocessor::addRemarkComments(const simplecpp::TokenList &tokens, std::vector<RemarkComment> &remarkComments) const
+std::vector<RemarkComment> Preprocessor::getRemarkComments(const simplecpp::TokenList &tokens) const
 {
+    std::vector<RemarkComment> remarkComments;
+
     for (const simplecpp::Token *tok = tokens.cfront(); tok; tok = tok->next) {
         if (!tok->comment)
             continue;
@@ -1226,4 +1217,6 @@ void Preprocessor::addRemarkComments(const simplecpp::TokenList &tokens, std::ve
         // Add the suppressions.
         remarkComments.emplace_back(relativeFilename, remarkedToken->location.line, remarkText);
     }
+
+    return remarkComments;
 }

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -120,9 +120,7 @@ public:
 
     std::vector<RemarkComment> getRemarkComments() const;
 
-    void addRemarkComments(std::vector<RemarkComment> &remarkComments) const;
-
-    void addRemarkComments(const simplecpp::TokenList &tokens, std::vector<RemarkComment> &remarkComments) const;
+    std::vector<RemarkComment> getRemarkComments(const simplecpp::TokenList &tokens) const;
 
     bool loadFiles(std::vector<std::string> &files);
 

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -98,6 +98,8 @@ public:
  * configurations that exist in a source file.
  */
 class CPPCHECKLIB WARN_UNUSED Preprocessor {
+    friend class TestPreprocessor;
+
 public:
     /** character that is inserted in expanded macros */
     static char macroChar;

--- a/lib/preprocessor.h
+++ b/lib/preprocessor.h
@@ -104,17 +104,29 @@ public:
 
     Preprocessor(simplecpp::TokenList& tokens, const Settings& settings, ErrorLogger &errorLogger, Standards::Language lang);
 
-    void inlineSuppressions(SuppressionList &suppressions);
+    void inlineSuppressions(SuppressionList &suppressions) const;
 
-    std::list<Directive> createDirectives() const;
+    void inlineSuppressions(const simplecpp::TokenList &tokens, SuppressionList &suppressions) const;
 
-    std::set<std::string> getConfigs() const;
+    void createDirectives(std::list<Directive> &directives) const;
+
+    static void createDirectives(const simplecpp::TokenList &tokens, std::list<Directive> &directives);
+
+    void getConfigs(std::set<std::string> &defined, std::set<std::string> &configs) const;
+
+    void getConfigs(const std::string &filename, const simplecpp::TokenList &tokens, std::set<std::string> &defined, std::set<std::string> &configs) const;
 
     std::vector<RemarkComment> getRemarkComments() const;
+
+    void addRemarkComments(std::vector<RemarkComment> &remarkComments) const;
+
+    void addRemarkComments(const simplecpp::TokenList &tokens, std::vector<RemarkComment> &remarkComments) const;
 
     bool loadFiles(std::vector<std::string> &files);
 
     void removeComments();
+
+    static void removeComments(simplecpp::TokenList &tokens);
 
     void setPlatformInfo();
 
@@ -132,6 +144,8 @@ public:
 
     void simplifyPragmaAsm();
 
+    static void simplifyPragmaAsm(simplecpp::TokenList &tokenList);
+
     static void getErrorMessages(ErrorLogger &errorLogger, const Settings &settings);
 
     /**
@@ -141,12 +155,15 @@ public:
 
     const simplecpp::Output* reportOutput(const simplecpp::OutputList &outputList, bool showerror);
 
-    void error(const simplecpp::Location& loc, const std::string &msg, simplecpp::Output::Type type);
+    void error(const simplecpp::Location& loc, const std::string &msg, simplecpp::Output::Type type) const;
 
     const simplecpp::Output* handleErrors(const simplecpp::OutputList &outputList);
 
+    void setLoadCallback(simplecpp::FileDataCache::load_callback_type cb) {
+        mFileCache.set_load_callback(std::move(cb));
+    }
+
 private:
-    static void simplifyPragmaAsmPrivate(simplecpp::TokenList &tokenList);
 
     /**
      * Include file types.
@@ -157,17 +174,13 @@ private:
     };
 
     void missingInclude(const simplecpp::Location& loc, const std::string &header, HeaderTypes headerType);
-    void invalidSuppression(const simplecpp::Location& loc, const std::string &msg);
-    void error(const simplecpp::Location& loc, const std::string &msg, const std::string& id);
-
-    void addRemarkComments(const simplecpp::TokenList &tokens, std::vector<RemarkComment> &remarkComments) const;
+    void invalidSuppression(const simplecpp::Location& loc, const std::string &msg) const;
+    void error(const simplecpp::Location& loc, const std::string &msg, const std::string& id) const;
 
     simplecpp::TokenList& mTokens;
 
     const Settings& mSettings;
     ErrorLogger &mErrorLogger;
-
-    /** list of all directives met while preprocessing file */
 
     simplecpp::FileDataCache mFileCache;
 

--- a/test/cli/performance_test.py
+++ b/test/cli/performance_test.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import time
 
 import pytest
 
@@ -413,3 +414,27 @@ def test_slow_bifurcate(tmpdir):
                 	}
                 }""")
     cppcheck([filename]) # should not take more than ~1 second
+
+
+@pytest.mark.timeout(60)
+def test_slow_many_headers(tmpdir):
+    # 14113
+    c_file = os.path.join(tmpdir, 'source.c')
+    h_file = os.path.join(tmpdir, 'header.h')
+    n_hdr = 128
+    with open(c_file, 'wt') as f:
+        f.write('#include "header.h"\n')
+    with open(h_file, 'wt') as f:
+        for i in range(n_hdr):
+            f.write(f'#ifdef CONFIG{i}\n#include "header{i}.h"\n#endif\n')
+    for i in range(n_hdr):
+        h_file_i = os.path.join(tmpdir, f"header{i}.h")
+        with open(h_file_i, 'wt') as f:
+            for j in range(2048):
+                f.write(f'#define MACRO{j}{(" "+str(j))*128}\n')
+            f.write(f'MACRO{i}\n')
+    # creating the files used for testing can be slow, so we use perf counter here instead
+    start = time.perf_counter_ns()
+    cppcheck(['-DCONFIG0', c_file])
+    end = time.perf_counter_ns()
+    assert end - start < 2 * 10**9 # max 2 sec

--- a/test/helpers.cpp
+++ b/test/helpers.cpp
@@ -124,7 +124,8 @@ void SimpleTokenizer2::preprocess(const char* code, std::size_t size, std::vecto
     // Tokenizer..
     tokenizer.list.createTokens(std::move(tokens2));
 
-    std::list<Directive> directives = preprocessor.createDirectives();
+    std::list<Directive> directives;
+    preprocessor.createDirectives(directives);
     tokenizer.setDirectives(std::move(directives));
 }
 

--- a/test/testcppcheck.cpp
+++ b/test/testcppcheck.cpp
@@ -527,7 +527,6 @@ private:
     void checkPlistOutput() const {
         Suppressions supprs;
         ErrorLogger2 errorLogger;
-        std::vector<std::string> files = {"textfile.txt"};
 
         {
             const auto s = dinit(Settings, $.templateFormat = templateFormat, $.plistOutput = "output");
@@ -535,7 +534,7 @@ private:
             CppCheck cppcheck(s, supprs, errorLogger, nullptr, false, {});
             const FileWithDetails fileWithDetails {file.path(), Path::identify(file.path(), false), 0};
 
-            cppcheck.checkPlistOutput(fileWithDetails, files);
+            cppcheck.checkPlistOutput(fileWithDetails);
             const std::string outputFile {"outputfile_" + std::to_string(std::hash<std::string> {}(fileWithDetails.spath())) + ".plist"};
             ASSERT(Path::exists(outputFile));
             std::remove(outputFile.c_str());
@@ -547,7 +546,7 @@ private:
             CppCheck cppcheck(s, supprs, errorLogger, nullptr, false, {});
             const FileWithDetails fileWithDetails {file.path(), Path::identify(file.path(), false), 0};
 
-            cppcheck.checkPlistOutput(fileWithDetails, files);
+            cppcheck.checkPlistOutput(fileWithDetails);
             const std::string outputFile {"outputfile_" + std::to_string(std::hash<std::string> {}(fileWithDetails.spath())) + ".plist"};
             ASSERT(Path::exists(outputFile));
             std::remove(outputFile.c_str());
@@ -557,7 +556,7 @@ private:
             Settings s;
             const ScopedFile file("file.c", "");
             CppCheck cppcheck(s, supprs, errorLogger, nullptr, false, {});
-            cppcheck.checkPlistOutput(FileWithDetails(file.path(), Path::identify(file.path(), false), 0), files);
+            cppcheck.checkPlistOutput(FileWithDetails(file.path(), Path::identify(file.path(), false), 0));
         }
     }
 

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -371,6 +371,8 @@ private:
         TEST_CASE(testMissingIncludeMixed);
         TEST_CASE(testMissingIncludeCheckConfig);
 
+        TEST_CASE(testLazyInclude);
+
         TEST_CASE(hasInclude);
 
         TEST_CASE(limitsDefines);
@@ -3051,6 +3053,36 @@ private:
                       "test.c:6:2: information: Include file: \"header4.h\" not found. [missingInclude]\n"
                       "test.c:9:2: information: Include file: \"" + missing3 + "\" not found. [missingInclude]\n"
                       "test.c:11:2: information: Include file: <" + missing4 + "> not found. Please note: Standard library headers do not need to be provided to get proper results. [missingIncludeSystem]\n", errout_str());
+    }
+
+    void testLazyInclude() {
+        const char *code = "#ifdef CONFIG1\n"
+                           "#include \"header1.h\"\n"
+                           "#include \"missing1.h\"\n"
+                           "#else\n"
+                           "#include \"header2.h\"\n"
+                           "#include \"missing2.h\"\n"
+                           "#endif\n";
+
+        std::vector<std::string> files;
+        simplecpp::TokenList tokens(code, files, "test.c");
+
+        ScopedFile header1("header1.h", "1");
+        ScopedFile header2("header2.h", "2");
+
+        Settings settings;
+        Preprocessor preprocessor(tokens, settings, *this, Standards::Language::CPP);
+
+        simplecpp::OutputList outputList;
+        simplecpp::TokenList tokens2 = preprocessor.preprocess("CONFIG1", files, outputList);
+        std::string out = tokens2.stringify();
+
+        simplecpp::FileDataCache &cache = preprocessor.mFileCache;
+
+        ASSERT_EQUALS("\n#line 1 \"header1.h\"\n1", out);
+        ASSERT_EQUALS(1, outputList.size());
+        ASSERT_EQUALS("Header not found: \"missing1.h\"", outputList.begin()->msg);
+        ASSERT_EQUALS(1, cache.size());
     }
 
     void hasInclude() {

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -137,8 +137,11 @@ private:
         preprocessor.simplifyPragmaAsm();
 
         std::map<std::string, std::string> cfgcode;
-        if (cfgs.empty())
-            cfgs = preprocessor.getConfigs();
+        if (cfgs.empty()) {
+            cfgs.insert("");
+            std::set<std::string> configDefines = { "__cplusplus" };
+            preprocessor.getConfigs(configDefines, cfgs);
+        }
         for (const std::string & config : cfgs) {
             try {
                 const bool writeLocations = (strstr(code, "#include") != nullptr);
@@ -394,10 +397,24 @@ private:
         simplecpp::OutputList outputList;
         simplecpp::TokenList tokens(code,files,"test.c",&outputList);
         Preprocessor preprocessor(tokens, settings, *this, Standards::Language::C);
+        std::set<std::string> configs = { "" };
+        std::set<std::string> configDefines = { "__cplusplus" };
+        for (const auto &define : settings.library.defines()) {
+            const std::string::size_type paren = define.find("(");
+            const std::string::size_type space = define.find(" ");
+            std::string::size_type end = space;
+            if (paren != std::string::npos && paren < space)
+                end = paren;
+            configDefines.insert(define.substr(0, end));
+        }
+        preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
+            Preprocessor::removeComments(data.tokens);
+            preprocessor.getConfigs(data.filename, data.tokens, configDefines, configs);
+        });
+        preprocessor.removeComments();
+        preprocessor.getConfigs(configDefines, configs);
         ASSERT(preprocessor.loadFiles(files));
         ASSERT(!preprocessor.reportOutput(outputList, true));
-        preprocessor.removeComments();
-        const std::set<std::string> configs = preprocessor.getConfigs();
         std::string ret;
         for (const std::string & config : configs)
             ret += config + '\n';
@@ -409,8 +426,11 @@ private:
         std::vector<std::string> files;
         simplecpp::TokenList tokens(code,files,"test.c");
         Preprocessor preprocessor(tokens, settingsDefault, *this, Standards::Language::C);
-        ASSERT(preprocessor.loadFiles(files));
+        preprocessor.setLoadCallback([](simplecpp::FileData &data) {
+            Preprocessor::removeComments(data.tokens);
+        });
         preprocessor.removeComments();
+        ASSERT(preprocessor.loadFiles(files));
         return preprocessor.calculateHash("");
     }
 

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -405,7 +405,7 @@ private:
         std::transform(settings.library.defines().begin(),
                        settings.library.defines().end(),
                        std::inserter(configDefines, configDefines.end()),
-                       [](const auto &define) { return define.substr(0, define.find_first_of("( ")); });
+                       [](const std::string &define) { return define.substr(0, define.find_first_of("( ")); });
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             Preprocessor::removeComments(data.tokens);
             preprocessor.getConfigs(data.filename, data.tokens, configDefines, configs);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -401,14 +401,8 @@ private:
         Preprocessor preprocessor(tokens, settings, *this, Standards::Language::C);
         std::set<std::string> configs = { "" };
         std::set<std::string> configDefines = { "__cplusplus" };
-        for (const auto &define : settings.library.defines()) {
-            const std::string::size_type paren = define.find("(");
-            const std::string::size_type space = define.find(" ");
-            std::string::size_type end = space;
-            if (paren != std::string::npos && paren < space)
-                end = paren;
-            configDefines.insert(define.substr(0, end));
-        }
+        for (const auto &define : settings.library.defines())
+            configDefines.insert(define.substr(0, define.find_first_of("( ")));
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             Preprocessor::removeComments(data.tokens);
             preprocessor.getConfigs(data.filename, data.tokens, configDefines, configs);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -32,6 +32,7 @@
 #include "fixture.h"
 #include "helpers.h"
 
+#include <algorithm>
 #include <cstring>
 #include <iterator>
 #include <list>
@@ -402,10 +403,13 @@ private:
         Preprocessor preprocessor(tokens, settings, *this, Standards::Language::C);
         std::set<std::string> configs = { "" };
         std::set<std::string> configDefines = { "__cplusplus" };
+        const auto getDefineName = [](const std::string &defineString) {
+            return defineString.substr(0, defineString.find_first_of("( "));
+        };
         std::transform(settings.library.defines().begin(),
                        settings.library.defines().end(),
                        std::inserter(configDefines, configDefines.end()),
-                       [](const std::string &define) { return define.substr(0, define.find_first_of("( ")); });
+                       getDefineName);
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             Preprocessor::removeComments(data.tokens);
             preprocessor.getConfigs(data.filename, data.tokens, configDefines, configs);

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -3077,7 +3077,7 @@ private:
         simplecpp::TokenList tokens2 = preprocessor.preprocess("CONFIG1", files, outputList);
         std::string out = tokens2.stringify();
 
-        simplecpp::FileDataCache &cache = preprocessor.mFileCache;
+        const simplecpp::FileDataCache &cache = preprocessor.mFileCache;
 
         ASSERT_EQUALS("\n#line 1 \"header1.h\"\n1", out);
         ASSERT_EQUALS(1, outputList.size());

--- a/test/testpreprocessor.cpp
+++ b/test/testpreprocessor.cpp
@@ -33,6 +33,7 @@
 #include "helpers.h"
 
 #include <cstring>
+#include <iterator>
 #include <list>
 #include <map>
 #include <set>
@@ -401,8 +402,10 @@ private:
         Preprocessor preprocessor(tokens, settings, *this, Standards::Language::C);
         std::set<std::string> configs = { "" };
         std::set<std::string> configDefines = { "__cplusplus" };
-        for (const auto &define : settings.library.defines())
-            configDefines.insert(define.substr(0, define.find_first_of("( ")));
+        std::transform(settings.library.defines().begin(),
+                       settings.library.defines().end(),
+                       std::inserter(configDefines, configDefines.end()),
+                       [](const auto &define) { return define.substr(0, define.find_first_of("( ")); });
         preprocessor.setLoadCallback([&](simplecpp::FileData &data) {
             Preprocessor::removeComments(data.tokens);
             preprocessor.getConfigs(data.filename, data.tokens, configDefines, configs);

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -603,9 +603,13 @@ private:
         std::vector<std::string> files;
         simplecpp::TokenList tokens1(code, files, filename, &outputList);
         Preprocessor preprocessor(tokens1, settings, *this, Path::identify(tokens1.getFiles()[0], false));
-        (void)preprocessor.reportOutput(outputList, true);
+        std::list<Directive> directives;
+        preprocessor.setLoadCallback([&](const simplecpp::FileData &data) {
+            Preprocessor::createDirectives(data.tokens, directives);
+        });
+        preprocessor.createDirectives(directives);
         ASSERT(preprocessor.loadFiles(files));
-        std::list<Directive> directives = preprocessor.createDirectives();
+        (void)preprocessor.reportOutput(outputList, true);
 
         TokenList tokenlist{settings, Path::identify(filename, false)};
         Tokenizer tokenizer(std::move(tokenlist), *this);


### PR DESCRIPTION
Improves check times for sources with many conditionally includes files by implementing lazy loading of headers. Lazy loading is only implemented for single-config checks because cppcheck currently needs to open all possibly included headers in order to discover configs automatically. Lazy loading for automatic configurations is possible by discovering new configurations as files are loaded, and it's something I think should be implemented in the future. I've done preliminary tests showing that it significantly speeds up check times when using `-f`, but there are some complications that need to be figured out and it's outside the scope of this PR.

Some changes have been made to `Preprocessor`; since preprocessing has to be done per-file as they are included, many functions have been changed or overloaded to act on a specific file instead of all previously loaded files. Some dumps have been changed to be completed after checking is done, when the full list of included files is known.

A test has been added to `test/cli/performance_test.py`.

### Benchmarks
Test file:
```
$ cat pic1.c
#include <xc.h>

```

Before:
```
$ cppcheck -I"C:\Program Files\Microchip\xc16\v2.10\support\generic\h" -I"C:\Program Files\Microchip\xc16\v2.10\support\dsPIC33E\h" -D __dsPIC33EP128GP504__ pic1.c --showtime=file-total
Checking pic1.c ...
Checking pic1.c: __dsPIC33EP128GP504__=1...
Check time: pic1.c: 2m 22.472s
```

After:
```
$ cppcheck -I"C:\Program Files\Microchip\xc16\v2.10\support\generic\h" -I"C:\Program Files\Microchip\xc16\v2.10\support\dsPIC33E\h" -D __dsPIC33EP128GP504__ pic1.c --showtime=file-total
Checking pic1.c ...
Checking pic1.c: __dsPIC33EP128GP504__=1...
Check time: pic1.c: 1.011s
```
