### PR TITLE
Fix #11538: Fix syntax error on C++23 'if consteval' / 'if !consteval'

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5721,7 +5721,22 @@ bool Tokenizer::simplifyTokenList1(const char FileName[])
 
     // if MACRO
     for (Token *tok = list.front(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "if|for|while %name% (")) {
+        if (Token::simpleMatch(tok, "if consteval {")) {
+            // 'if consteval { ... }' -> 'if ( __cppcheck_consteval__ ) { ... }'
+            Token *parTok = tok->next();
+            parTok->str("(");
+            Token *evalTok = parTok->insertToken("__cppcheck_consteval__");
+            evalTok->originalName("consteval");
+            evalTok->insertToken(")");
+        } else if (Token::simpleMatch(tok, "if ! consteval {")) {
+            // 'if !consteval { ... }' -> 'if ( ! __cppcheck_consteval__ ) { ... }'
+            Token *notTok = tok->next();
+            notTok->insertTokenBefore("(");
+            Token *evalTok = notTok->next();
+            evalTok->str("__cppcheck_consteval__");
+            evalTok->originalName("consteval");
+            evalTok->insertToken(")");
+        } else if (Token::Match(tok, "if|for|while %name% (")) {
             if (Token::simpleMatch(tok, "for each")) {
                 // 'for each (x in y )' -> 'for (x : y)'
                 if (Token* in = Token::findsimplematch(tok->tokAt(2), "in", tok->linkAt(2)))

--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -5721,7 +5721,22 @@ bool Tokenizer::simplifyTokenList1(const char FileName[])
 
     // if MACRO
     for (Token *tok = list.front(); tok; tok = tok->next()) {
-        if (Token::Match(tok, "if|for|while %name% (")) {
+        if (Token::simpleMatch(tok, "if consteval {")) {
+            // 'if consteval { ... }' -> 'if ( __cppcheck_consteval__ ) { ... }'
+            Token *parTok = tok->next();
+            parTok->str("(");
+            Token *evalTok = parTok->insertToken("__cppcheck_consteval__");
+            evalTok->originalName("consteval");
+            evalTok->insertToken(")");
+        } else if (Token::Match(tok, "if !|not consteval {")) {
+            // 'if !consteval { ... }' / 'if not consteval { ... }' -> 'if ( ! __cppcheck_consteval__ ) { ... }'
+            Token *notTok = tok->next();
+            notTok->insertTokenBefore("(");
+            Token *evalTok = notTok->next();
+            evalTok->str("__cppcheck_consteval__");
+            evalTok->originalName("consteval");
+            evalTok->insertToken(")");
+        } else if (Token::Match(tok, "if|for|while %name% (")) {
             if (Token::simpleMatch(tok, "for each")) {
                 // 'for each (x in y )' -> 'for (x : y)'
                 if (Token* in = Token::findsimplematch(tok->tokAt(2), "in", tok->linkAt(2)))

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -104,6 +104,7 @@ private:
 
         TEST_CASE(foreach);     // #3690
         TEST_CASE(ifconstexpr);
+        TEST_CASE(ifconsteval);
 
         TEST_CASE(combineOperators);
 
@@ -1040,6 +1041,18 @@ private:
         ASSERT_EQUALS(
             "[test.cpp:1:27]: (debug) valueFlowConditionExpressions bailout: Skipping function due to incomplete variable FOO [valueFlowBailoutIncompleteVar]\n",
             filter_valueflow(errout_str()));
+    }
+
+    void ifconsteval() {
+        ASSERT_EQUALS("void f ( ) { if ( __cppcheck_consteval__ ) { bar ( ) ; } }", tokenizeAndStringify("void f() { if consteval { bar(); } }"));
+        filter_valueflow(errout_str());
+
+        ASSERT_EQUALS("void f ( ) { if ( ! __cppcheck_consteval__ ) { bar ( ) ; } }", tokenizeAndStringify("void f() { if !consteval { bar(); } }"));
+        filter_valueflow(errout_str());
+
+        ASSERT_EQUALS("void f ( ) { if ( __cppcheck_consteval__ ) { bar ( ) ; } else { baz ( ) ; } }",
+                       tokenizeAndStringify("void f() { if consteval { bar(); } else { baz(); } }"));
+        filter_valueflow(errout_str());
     }
 
     void combineOperators() {

--- a/test/testtokenize.cpp
+++ b/test/testtokenize.cpp
@@ -104,6 +104,7 @@ private:
 
         TEST_CASE(foreach);     // #3690
         TEST_CASE(ifconstexpr);
+        TEST_CASE(ifconsteval);
 
         TEST_CASE(combineOperators);
 
@@ -1040,6 +1041,22 @@ private:
         ASSERT_EQUALS(
             "[test.cpp:1:27]: (debug) valueFlowConditionExpressions bailout: Skipping function due to incomplete variable FOO [valueFlowBailoutIncompleteVar]\n",
             filter_valueflow(errout_str()));
+    }
+
+    void ifconsteval() {
+        ASSERT_EQUALS("void f ( ) { if ( __cppcheck_consteval__ ) { bar ( ) ; } }", tokenizeAndStringify("void f() { if consteval { bar(); } }"));
+        filter_valueflow(errout_str());
+
+        ASSERT_EQUALS("void f ( ) { if ( ! __cppcheck_consteval__ ) { bar ( ) ; } }", tokenizeAndStringify("void f() { if !consteval { bar(); } }"));
+        filter_valueflow(errout_str());
+
+        ASSERT_EQUALS("void f ( ) { if ( __cppcheck_consteval__ ) { bar ( ) ; } else { baz ( ) ; } }",
+                      tokenizeAndStringify("void f() { if consteval { bar(); } else { baz(); } }"));
+        filter_valueflow(errout_str());
+
+        ASSERT_EQUALS("constexpr bool is_runtime_evaluated ( ) noexcept ( true ) { if ( ! __cppcheck_consteval__ ) { return true ; } else { return false ; } }",
+                      tokenizeAndStringify("constexpr bool is_runtime_evaluated() noexcept { if not consteval { return true; } else { return false; } }"));
+        filter_valueflow(errout_str());
     }
 
     void combineOperators() {


### PR DESCRIPTION
The tokenizer only recognized `if constexpr (...)` and treated any other `if <name>` without parentheses as a syntax error, so C++23's `if consteval { ... }` and `if !consteval { ... }` were rejected.

Rewrite them to `if ( __cppcheck_consteval__ ) { ... }` and `if ( ! __cppcheck_consteval__ ) { ... }` respectively, using a synthetic unresolved symbol rather than a boolean literal so that valueflow can't treat the condition as always true/false.