### PR TITLE
Fix #14949: FP leakNoVarFunctionCall when passing resource to constructor

### DIFF
--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1046,22 +1046,20 @@ void CheckMemoryLeakNoVarImpl::checkForUnreleasedInputArgument(const Scope *scop
             const AllocType alloc = getAllocationType(arg, 0);
             if (alloc == No)
                 continue;
-            else {
-                const Token* typeTok = arg->next();
-                bool bail = !typeTok->isStandardType() &&
-                            (!typeTok->valueType() ||
-                             (typeTok->valueType()->type < ValueType::Type::SMART_POINTER &&
-                              typeTok->valueType()->type != ValueType::Type::POD)) &&
-                            !mSettings.library.detectContainerOrIterator(typeTok) &&
-                            !mSettings.library.podtype(typeTok->expressionString());
-                if (bail && typeTok->type() && typeTok->type()->classScope &&
-                    typeTok->type()->classScope->numConstructors == 0 &&
-                    typeTok->type()->classScope->getDestructor() == nullptr) {
-                    bail = false;
-                }
-                if (bail)
-                    continue;
+            const Token* typeTok = arg->next();
+            bool bail = !typeTok->isStandardType() &&
+                        (!typeTok->valueType() ||
+                         (typeTok->valueType()->type < ValueType::Type::SMART_POINTER &&
+                          typeTok->valueType()->type != ValueType::Type::POD)) &&
+                        !mSettings.library.detectContainerOrIterator(typeTok) &&
+                        !mSettings.library.podtype(typeTok->expressionString());
+            if (bail && typeTok->type() && typeTok->type()->classScope &&
+                typeTok->type()->classScope->numConstructors == 0 &&
+                typeTok->type()->classScope->getDestructor() == nullptr) {
+                bail = false;
             }
+            if (bail)
+                continue;
             if (isReopenStandardStream(arg))
                 continue;
             if (tok->function()) {

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -1046,7 +1046,6 @@ void CheckMemoryLeakNoVarImpl::checkForUnreleasedInputArgument(const Scope *scop
             const AllocType alloc = getAllocationType(arg, 0);
             if (alloc == No)
                 continue;
-            //if (alloc == New || alloc == NewArray) {
             else {
                 const Token* typeTok = arg->next();
                 bool bail = !typeTok->isStandardType() &&

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -517,7 +517,7 @@ void CheckMemoryLeakInClassImpl::check()
     // only check classes and structures
     for (const Scope * scope : symbolDatabase->classAndStructScopes) {
         for (const Variable &var : scope->varlist) {
-            if (!var.isStatic()) {
+            if (!var.isStatic() && (var.isPointer() || var.isPointerArray())) {
                 // allocation but no deallocation of private variables in public function..
                 const Token *tok = var.typeStartToken();
                 // Either it is of standard type or a non-derived type

--- a/lib/checkmemoryleak.cpp
+++ b/lib/checkmemoryleak.cpp
@@ -517,7 +517,7 @@ void CheckMemoryLeakInClassImpl::check()
     // only check classes and structures
     for (const Scope * scope : symbolDatabase->classAndStructScopes) {
         for (const Variable &var : scope->varlist) {
-            if (!var.isStatic() && (var.isPointer() || var.isPointerArray())) {
+            if (!var.isStatic()) {
                 // allocation but no deallocation of private variables in public function..
                 const Token *tok = var.typeStartToken();
                 // Either it is of standard type or a non-derived type
@@ -1046,7 +1046,8 @@ void CheckMemoryLeakNoVarImpl::checkForUnreleasedInputArgument(const Scope *scop
             const AllocType alloc = getAllocationType(arg, 0);
             if (alloc == No)
                 continue;
-            if (alloc == New || alloc == NewArray) {
+            //if (alloc == New || alloc == NewArray) {
+            else {
                 const Token* typeTok = arg->next();
                 bool bail = !typeTok->isStandardType() &&
                             (!typeTok->valueType() ||

--- a/test/testmemleak.cpp
+++ b/test/testmemleak.cpp
@@ -2628,6 +2628,23 @@ private:
                       "[test.cpp:7:12]: (error) Allocation with f2, assert doesn't release it. [leakNoVarFunctionCall]\n"
                       "[test.cpp:8:12]: (error) Allocation with f3, assert doesn't release it. [leakNoVarFunctionCall]\n",
                       errout_str());
+        check("struct S {\n"
+              "    explicit S(int fd) {\n"
+              "        m_fd = fd;\n"
+              "    }\n"
+              "    ~S() {\n"
+              "        if (m_fd >= 0)\n"
+              "            close(m_fd); \n"
+              "    }\n"
+              "    int m_fd = -1;\n"
+              "};\n"
+              "S g(char *name) {\n"
+              "    return S(mkostemp(name, 0));\n"
+              "}\n"
+              "void f(char* ptr) {\n"
+              "    S s = g(ptr);\n"
+              "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     void missingAssignment() {


### PR DESCRIPTION
Remove Variable and AllocType type checking when searching for unreleased arguments and when checking if member variables are deallocated in destructor.

This method is a little heavy handed and might hurt performance, but I am unsure how we could be more precise.  It would be nice if we could check "If var.isResource() or var.needsToBeDeallocated()" but that would be a different PR i think.