### PR TITLE
gtk.cfg: Remove pure annotation from g_str_has_prefix/suffix

### DIFF
--- a/cfg/gtk.cfg
+++ b/cfg/gtk.cfg
@@ -5221,7 +5221,6 @@
   <!-- gboolean g_str_has_prefix (const gchar* str, const gchar* prefix); -->
   <!-- gboolean g_str_has_suffix (const gchar* str, const gchar* prefix); -->
   <function name="g_str_has_prefix,g_str_has_suffix">
-    <pure/>
     <leak-ignore/>
     <noreturn>false</noreturn>
     <returnValue type="gboolean"/>

--- a/test/cfg/gtk.c
+++ b/test/cfg/gtk.c
@@ -59,8 +59,14 @@ void validCode(int argInt, GHashTableIter * hash_table_iter, GHashTable * hash_t
     g_string_free(pGStr1, TRUE);
 
     gchar * pGchar1 = g_strconcat("a", "b", NULL);
+
+    // g_str_has_prefix and g_str_has_suffix can have side effects because they use
+    // g_return_val_if_fail, which logs to the console upon failure
+    // cppcheck-suppress assertWithSideEffect
     g_assert_true(g_str_has_prefix(pGchar1, "a"));
+    // cppcheck-suppress assertWithSideEffect
     g_assert_true(g_str_has_suffix(pGchar1, "b"));
+
     printf("%s", pGchar1);
     g_free(pGchar1);
 


### PR DESCRIPTION
`g_str_has_prefix` and `g_str_has_suffix` are not technically pure because they can log to the console if a precondition fails.

This partially reverts commit 7cc7c0bb5.

---

Some notes:

The original `gtk.cfg` change hasn't been released yet, so the revert shouldn't cause any churn for users.

GLib has code like this:

```c
gboolean (g_str_has_prefix) (const gchar *str,
                             const gchar *prefix)
{
  g_return_val_if_fail (str != NULL, FALSE);
  g_return_val_if_fail (prefix != NULL, FALSE);

  return strncmp (str, prefix, strlen (prefix)) == 0;
}
```

Most real-world code is treating this function as safe to call inside of an assert, even though it could technically have side effects if one of the preconditions fails.

I removed the pure annotation to err on the side of correctness and pedantry, even though most projects would view the warnings as "false positives" from a practical perspective.

Here is example usage from QEMU:

```c
char *qemu_chr_get_filename(Chardev *chr)
{
    ChardevClass *cc = CHARDEV_GET_CLASS(chr);
    const char *typename;

    if (cc->chr_get_filename) {
        return cc->chr_get_filename(chr);
    }

    typename = object_get_typename(OBJECT(chr));
    assert(g_str_has_prefix(typename, "chardev-"));
    return g_strdup(typename + 8);
}
```