### PR TITLE
Fixed Qt config macro declaration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,6 +101,7 @@ daisuke-chiba
 Daniel Friedrich
 David Korczynski
 Daniel Marjamäki
+Daschle Newberry
 David Hallas
 David Korth
 Dávid Slivka

--- a/cfg/qt.cfg
+++ b/cfg/qt.cfg
@@ -5520,7 +5520,7 @@
   <define name="Q_OVERRIDE(x)" value=""/>
   <define name="Q_PLUGIN_METADATA(x)" value=""/>
   <define name="Q_ASSERT(condition)" value="assert(condition)"/>
-  <define name="Q_ASSERT_X(condition, where, what)" value="assert(condition)"/>
+  <define name="Q_ASSERT_X(condition, where, what)" value="assert(condition); (void)(where); (void)(what)"/>
   <define name="QTC_ASSERT_STRINGIFY_HELPER(x)" value="#x"/>
   <define name="QTC_ASSERT_STRINGIFY(x)" value="QTC_ASSERT_STRINGIFY_HELPER(x)"/>
   <define name="QTC_ASSERT_STRING(cond)" value="::Utils::writeAssertLocation( &quot;\&quot;&quot; cond&quot;\&quot; in file &quot; __FILE__ &quot;, line &quot; QTC_ASSERT_STRINGIFY(__LINE__))"/>

--- a/test/cfg/qt.cpp
+++ b/test/cfg/qt.cpp
@@ -894,6 +894,13 @@ int qdateIsValid()
     return qd.month(); 
 }
 
+void qAssertX()
+{
+    const char *where = "test";
+    const char *what = "assertion failed";
+    Q_ASSERT_X(false, where, what);
+}
+
 struct S_QTimer_connect : QObject { // #13846
     S_QTimer_connect() {
         // cppcheck-suppress checkLibraryFunction - timeout() is a signal from QTimer


### PR DESCRIPTION
The macro definition of `Q_ASSERT_X` results in false positives.

### Example
```cpp
#include <QDebug>

void test()
{
    const char *where = "test";
    const char *what = "assertion failed";

    Q_ASSERT_X(false, where, what);
}
 ````
 
 This code block results in:
```commandline
style: Variable 'where' is assigned a value that is never used. [unreadVariable]
style: Variable 'what' is assigned a value that is never used. [unreadVariable]
```

 The existing definition discards `where` and `what` arguments when modeling `Q_ASSERT_X`. The fix preserves these arguments using `(void) (what)` and `(void) (where)`