### PR TITLE
AnalyzerInformation: don't store inline suppressions (Fix #14974: [regression])

### DIFF
--- a/lib/cppcheck.cpp
+++ b/lib/cppcheck.cpp
@@ -189,8 +189,9 @@ private:
         const auto errorMessage = SuppressionList::ErrorMessage::fromErrorMessage(msg, macroNames);
 
         bool suppressed = false;
+        bool inlineSupressed;
 
-        if (mSuppressions.nomsg.isSuppressed(errorMessage, mUseGlobalSuppressions)) {
+        if (mSuppressions.nomsg.isSuppressed(errorMessage, mUseGlobalSuppressions, &inlineSupressed)) {
             // Safety: Report critical errors to ErrorLogger
             if (mSettings.safety && ErrorLogger::isCriticalErrorId(msg.id)) {
                 mExitCode = 1;
@@ -220,7 +221,7 @@ private:
         if (!mSettings.emitDuplicates && !mErrorList.emplace(std::move(errmsg)).second)
             return;
 
-        if (mAnalyzerInformation)
+        if (mAnalyzerInformation && !inlineSupressed)
             mAnalyzerInformation->reportErr(msg);
 
         if (suppressed)

--- a/lib/suppressions.cpp
+++ b/lib/suppressions.cpp
@@ -472,10 +472,10 @@ bool SuppressionList::Suppression::isMatch(const SuppressionList::ErrorMessage &
     cppcheck::unreachable();
 }
 
-bool SuppressionList::isSuppressed(const SuppressionList::ErrorMessage &errmsg, bool global)
-{
+bool SuppressionList::isSuppressed(const SuppressionList::ErrorMessage &errmsg, bool global, bool *inlineSupressed) {
     std::lock_guard<std::mutex> lg(mSuppressionsSync);
-
+    if (inlineSupressed)
+        *inlineSupressed = false;
     // TODO: handle unmatchedPolyspaceSuppression?
     const bool unmatchedSuppression(errmsg.errorId == "unmatchedSuppression");
     bool returnValue = false;
@@ -484,8 +484,11 @@ bool SuppressionList::isSuppressed(const SuppressionList::ErrorMessage &errmsg, 
             continue;
         if (unmatchedSuppression && s.errorId != errmsg.errorId)
             continue;
-        if (s.isMatch(errmsg))
+        if (s.isMatch(errmsg)) {
             returnValue = true;
+            if (inlineSupressed && s.isInline)
+                *inlineSupressed = true;
+        }
     }
     return returnValue;
 }

--- a/lib/suppressions.h
+++ b/lib/suppressions.h
@@ -233,9 +233,10 @@ public:
      * @brief Returns true if this message should not be shown to the user.
      * @param errmsg error message
      * @param global use global suppressions
+     * @param inlineSupressed is true if there exists an inline suppression for this error
      * @return true if this error is suppressed.
      */
-    bool isSuppressed(const ErrorMessage &errmsg, bool global = true);
+    bool isSuppressed(const ErrorMessage &errmsg, bool global = true, bool *inlineSupressed = nullptr);
 
     /**
      * @brief Returns true if this message is "explicitly" suppressed. The suppression "id" must match textually exactly.


### PR DESCRIPTION
There is no situation where a inline suppressed error is needed again. And after loading an analysis we don't know if there were inline suppressions because we don't look at the code again.
We have to keep errors that are suppressed otherwise, since command line parameters can change etc., but an inline suppression can not change without changing the file hash which invalidates the cache entry anyways.