### PR TITLE
Fix 14994: False negative: `nullPointer` with `getenv`

### DIFF
--- a/cfg/cppcheck-cfg.rng
+++ b/cfg/cppcheck-cfg.rng
@@ -167,6 +167,9 @@
                 </attribute>
               </optional>
               <optional>
+                <attribute name="possible-null"><ref name="DATA-BOOL"/></attribute>
+              </optional>
+              <optional>
                 <attribute name="container">
                   <data type="positiveInteger"/>
                 </attribute>

--- a/cfg/std.cfg
+++ b/cfg/std.cfg
@@ -2534,7 +2534,7 @@
   <!-- char * getenv(const char *name); -->
   <function name="getenv,std::getenv">
     <use-retval/>
-    <returnValue type="char *"/>
+    <returnValue type="char *" possible-null="true"/>
     <noreturn>false</noreturn>
     <leak-ignore/>
     <arg nr="1" direction="in">

--- a/lib/library.cpp
+++ b/lib/library.cpp
@@ -900,6 +900,8 @@ Library::Error Library::loadFunction(const tinyxml2::XMLElement * const node, co
                 mData->mReturnValue[name] = expr;
             if (const char *type = functionnode->Attribute("type"))
                 mData->mReturnValueType[name] = type;
+            if (functionnode->BoolAttribute("possible-null", false))
+                func.isPossibleNull = true;
             if (const char *container = functionnode->Attribute("container"))
                 mData->mReturnValueContainer[name] = strToInt<int>(container);
             // cppcheck-suppress shadowFunction - TODO: fix this

--- a/lib/library.h
+++ b/lib/library.h
@@ -314,6 +314,7 @@ public:
         bool leakignore{};
         bool isconst{};
         bool ispure{};
+        bool isPossibleNull{};
         UseRetValType useretval = UseRetValType::NONE;
         bool ignore{};  // ignore functions/macros from a library (gtk, qt etc)
         bool formatstr{};

--- a/lib/valueflow.cpp
+++ b/lib/valueflow.cpp
@@ -7234,6 +7234,17 @@ static void valueFlowUnknownFunctionReturn(TokenList& tokenlist, const Settings&
             }
         }
 
+        const Token *ftok = tok->astOperand1();
+        while (ftok && Token::simpleMatch(ftok, "::"))
+            ftok = ftok->astOperand2() ? ftok->astOperand2() : ftok->astOperand1();
+        const Library::Function *func = ftok ? settings.library.getFunction(ftok) : nullptr;
+        if (func && func->isPossibleNull) {
+            ValueFlow::Value value(0);
+            value.setPossible();
+            value.errorPath.emplace_back(tok, "Assuming function returns NULL");
+            setTokenValue(tok, std::move(value), settings);
+        }
+
         if (settings.checkUnknownFunctionReturn.find(tok->strAt(-1)) == settings.checkUnknownFunctionReturn.end())
             continue;
         std::vector<MathLib::bigint> unknownValues = settings.library.unknownReturnValues(tok->astOperand1());

--- a/test/testlibrary.cpp
+++ b/test/testlibrary.cpp
@@ -57,6 +57,7 @@ private:
         TEST_CASE(function_method);
         TEST_CASE(function_baseClassMethod); // calling method in base class
         TEST_CASE(function_warn);
+        TEST_CASE(function_possible_null);
         TEST_CASE(memory);
         TEST_CASE(memory2); // define extra "free" allocation functions
         TEST_CASE(memory3);
@@ -641,6 +642,24 @@ private:
             ASSERT_EQUALS(Standards::C89, b->standards.c);
             ASSERT_EQUALS(Standards::CPP11, b->standards.cpp);
         }
+    }
+
+    void function_possible_null() const {
+        constexpr char xmldata[] = "<?xml version=\"1.0\"?>\n"
+                                   "<def>\n"
+                                   "  <function name=\"a\">\n"
+                                   "    <returnValue type=\"void *\" possible-null=\"true\"/>\n"
+                                   "  </function>\n"
+                                   "</def>";
+
+        Library library;
+        ASSERT(LibraryHelper::loadxmldata(library, xmldata, sizeof(xmldata)));
+
+        const char code[] = "a();\n";
+        const SimpleTokenList tokenList(code);
+
+        const Library::Function *a = library.getFunction(tokenList.front());
+        ASSERT(a->isPossibleNull);
     }
 
     void memory() const {

--- a/test/testnullpointer.cpp
+++ b/test/testnullpointer.cpp
@@ -148,6 +148,9 @@ private:
         TEST_CASE(nullpointer108);
         TEST_CASE(nullpointer109);
         TEST_CASE(nullpointer110); // #14937
+        TEST_CASE(nullpointer111);
+        TEST_CASE(nullpointer112);
+        TEST_CASE(nullpointer113);
         TEST_CASE(nullpointer_addressOf); // address of
         TEST_CASE(nullpointerSwitch); // #2626
         TEST_CASE(nullpointer_cast); // #4692
@@ -3144,6 +3147,34 @@ private:
               "    *p = 1;\n"
               "}\n",
               dinit(CheckOptions, $.inconclusive = true));
+        ASSERT_EQUALS("", errout_str());
+    }
+
+    void nullpointer111()
+    {
+        check("void f(void) {\n"
+              "    char *str = getenv(\"TMP\");\n"
+              "    char *c = *str;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3:16]: (warning) Possible null pointer dereference: str [nullPointer]\n", errout_str());
+    }
+
+    void nullpointer112()
+    {
+        check("void f(void) {\n"
+              "    char *str = std::getenv(\"TMP\");\n"
+              "    char *c = *str;\n"
+              "}\n");
+        ASSERT_EQUALS("[test.cpp:3:16]: (warning) Possible null pointer dereference: str [nullPointer]\n", errout_str());
+    }
+
+    void nullpointer113()
+    {
+        check("void f(void) {\n"
+              "    char *str = std::getenv(\"TMP\");\n"
+              "    if (!str) return;\n"
+              "    char *c = *str;\n"
+              "}\n");
         ASSERT_EQUALS("", errout_str());
     }
 


### PR DESCRIPTION
This adds a new attribute to the library configuration that signifies that a function may return `NULL`. I was planning to add this to other functions, such as `strchr` and family, but unfortunately it leads to false positives ([see this test case](https://github.com/ludviggunne/cppcheck/blob/23cc32e2e6efb7607c426b39d54ec57d7952fb71/test/testnullpointer.cpp#L3013)). In any case I think some kind of update to the config format is needed to handle these kind of FNs without hardcoding.