### PR TITLE
Fix #15005: FP uninitdata with compound assignment or increment

### DIFF
--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1295,17 +1295,28 @@ const Token* CheckUninitVarImpl::isVariableUsage(const Token *vartok, const Libr
             }
             if (alloc != NO_ALLOC && astIsRhs(valueExpr))
                 return nullptr;
-        } else if (tok->astParent() && tok->astParent()->isAssignmentOp()) {
-            // all variables in a compound assignment get read, so NO_ALLOC is
-            // never acceptable
-            if (alloc != NO_ALLOC) {
-                // if its not a pointer or array, or not dereferenced it is safe
-                if (!(pointer || alloc == ARRAY) || !derefValue) {
-                    return nullptr;
-                }
+        } else if (tok->astParent() && (tok->astParent()->isAssignmentOp() || tok->astParent()->isIncDecOp())) {
+            // NO_ALLOC -> no matter what we read the uninitialized memory.
+            // pointer/array -> safe, as long as we don't dereference
+            //
+            // sometimes "pointer" and "alloc == ARRAY" are used for things
+            // that aren't actually pointers or arrays.
+            //
+            // this test
+            // ctu("void increment(int& i) { ++i; }\n" // #6475
+            // uses the callback which hardcodes pointer = true and alloc = ARRAY
+            // though int& isn't a pointer or an array, and we expect this
+            // function to not return nullptr even though i is not dereferenced
+            bool isPtr = pointer;
+            bool isArr = alloc == ARRAY;
+            if (vartok && vartok->variable()) {
+                isPtr = vartok->variable()->isPointer();
+                isArr = vartok->variable()->isArray();
+            }
+            if ((alloc != NO_ALLOC) && ((isPtr || isArr) && !derefValue)) {
+                return nullptr;
             }
         }
-
     }
 
     // Initialize reference variable

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -834,7 +834,7 @@ bool CheckUninitVarImpl::checkScopeForVariable(const Token *tok, const Variable&
                         }
                     }
                 }
-                if (Token::simpleMatch(parent->astParent(), "=") && astIsLHS(parent)) {
+                if (parent->astParent() && parent->astParent()->isAssignmentOp() && astIsLHS(parent)) {
                     const Token *eq = parent->astParent();
                     if (const Token *errorToken = checkExpr(eq->astOperand2(), var, *alloc, number_of_if==0)) {
                         if (!suppressErrors)
@@ -1295,7 +1295,17 @@ const Token* CheckUninitVarImpl::isVariableUsage(const Token *vartok, const Libr
             }
             if (alloc != NO_ALLOC && astIsRhs(valueExpr))
                 return nullptr;
+        } else if (tok->astParent() && tok->astParent()->isAssignmentOp()) {
+            // all variables in a compound assignment get read, so NO_ALLOC is
+            // never acceptable
+            if (alloc != NO_ALLOC) {
+                // if its not a pointer or array, or not dereferenced it is safe
+                if (!(pointer || alloc == ARRAY) || !derefValue) {
+                    return nullptr;
+                }
+            }
         }
+
     }
 
     // Initialize reference variable

--- a/lib/checkuninitvar.cpp
+++ b/lib/checkuninitvar.cpp
@@ -1298,17 +1298,9 @@ const Token* CheckUninitVarImpl::isVariableUsage(const Token *vartok, const Libr
         } else if (tok->astParent() && (tok->astParent()->isAssignmentOp() || tok->astParent()->isIncDecOp())) {
             // NO_ALLOC -> no matter what we read the uninitialized memory.
             // pointer/array -> safe, as long as we don't dereference
-            //
-            // sometimes "pointer" and "alloc == ARRAY" are used for things
-            // that aren't actually pointers or arrays.
-            //
-            // this test
-            // ctu("void increment(int& i) { ++i; }\n" // #6475
-            // uses the callback which hardcodes pointer = true and alloc = ARRAY
-            // though int& isn't a pointer or an array, and we expect this
-            // function to not return nullptr even though i is not dereferenced
             bool isPtr = pointer;
             bool isArr = alloc == ARRAY;
+            // "pointer" and "alloc" get set for non-ptr non-array var
             if (vartok && vartok->variable()) {
                 isPtr = vartok->variable()->isPointer();
                 isArr = vartok->variable()->isArray();

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -2205,11 +2205,9 @@ private:
 
 
         checkUninitVar("void f() {\n"
-                       "    char *buf = (char *)malloc(1);\n"
-                       "    if (!buf)\n"
-                       "        return NULL;\n"
-                       "    buf += 1;\n"
-                       "    free(buf - 1);\n"
+                       "    char *p = new char;\n"
+                       "    p += 1;\n"
+                       "    delete (p - 1);\n"
                        "}\n");
         ASSERT_EQUALS("", errout_str());
 
@@ -2221,6 +2219,20 @@ private:
                        "    free(buf);\n"
                        "}\n");
         ASSERT_EQUALS("[test.cpp:5:15]: (error) Memory is allocated but not initialized: buf[0] [uninitdata]\n", errout_str());
+
+        checkUninitVar("void g() {\n"
+                       "    int* p = new int;\n"
+                       "    p++;\n"
+                       "    delete (p - 1);\n"
+                       "}\n");
+        ASSERT_EQUALS("", errout_str());
+
+        checkUninitVar("void g() {\n"
+                       "    int* p = new int;\n"
+                       "    ++p; // FP\n"
+                       "    delete (p - 1);\n"
+                       "}\n");
+        ASSERT_EQUALS("", errout_str());
     }
 
     // class / struct..

--- a/test/testuninitvar.cpp
+++ b/test/testuninitvar.cpp
@@ -2202,6 +2202,25 @@ private:
                        "    return i;\n"
                        "}\n");
         ASSERT_EQUALS("", errout_str());
+
+
+        checkUninitVar("void f() {\n"
+                       "    char *buf = (char *)malloc(1);\n"
+                       "    if (!buf)\n"
+                       "        return NULL;\n"
+                       "    buf += 1;\n"
+                       "    free(buf - 1);\n"
+                       "}\n");
+        ASSERT_EQUALS("", errout_str());
+
+        checkUninitVar("void f() {\n"
+                       "    char *buf = (char *)malloc(1);\n"
+                       "    if (!buf)\n"
+                       "        return NULL;\n"
+                       "    buf += buf[0];\n"
+                       "    free(buf);\n"
+                       "}\n");
+        ASSERT_EQUALS("[test.cpp:5:15]: (error) Memory is allocated but not initialized: buf[0] [uninitdata]\n", errout_str());
     }
 
     // class / struct..


### PR DESCRIPTION
isVariableUsage() currently returns nullptr for the lhs of assignment operators, because unless it's a pointer that gets dereferenced, it is just getting overwritten and its potentially uninitialized value is not read. I extend this idea to compound assignment and increment/decrement operators. 

While working on this, I found some issues with CTU analysis.
```
        valueFlowUninit("void increment(int& i) { ++i; }\n" // #6475
                        "int f() {\n"
                        "    int n;\n"
                        "    increment(n);\n"
                        "    return n;\n"
                        "}\n");
        ASSERT_EQUALS("[test.cpp:4:15] -> [test.cpp:1:28]: (warning) Uninitialized variable: i [uninitvar]\n", errout_str());
```
this test only works because of the false positive "usage" from the increment operator. For example, this test breaks if we use regular assignment because of the current code properly handling "="

this code
```
void increment(int& i) { i = i + 1; }
int f() {
    int n;
    increment(n);
    return n;
}
```
misses the ctu error, and only throws
```
Checking examples/ctu3.cpp ...
examples/ctu3.cpp:1:30: warning: Uninitialized variable: i [uninitvar]
void increment(int& i) { i = i + 1; }
                             ^
examples/ctu3.cpp:4:15: note: Calling function 'increment', 1st argument 'n' value is <Uninit>
    increment(n);
              ^
examples/ctu3.cpp:1:30: note: Uninitialized variable: i
void increment(int& i) { i = i + 1; }
                             ^
```

I think that the problem has to do with
```
// NOLINTNEXTLINE(readability-non-const-parameter) - used as callback so we need to preserve the signature
static bool isVariableUsage(const Settings &settings, const Token *vartok, MathLib::bigint *value)
{
    (void)value;
    return !!CheckUninitVarImpl::isVariableUsage(vartok, settings.library, true, CheckUninitVarImpl::Alloc::ARRAY);
}
```

the hardcoded pointer=true and alloc=ARRAY assignments tell isVariableUsage to return nullptr if it i isn't dereferenced, which it isn't. If we are going to hardcode these values to be this conservative then this test should fail because it currently only passes due to the FP bug I want to fix. I currently have a workaround where I use vartok->variable() to determine whether something is actually a pointer/array. 

Maybe there can be another PR where we rework the ctu/uninitvar connection. Notably since I don't touch the "=" branch of the code the false negative I mentioned above remains unfixed. Let me know if I should apply my vartok workaround to that code in this PR, if it should be another PR, or if its just the wrong idea overall. 