### PR TITLE
Fix #5738: false duplicate warnings with string prefix macros

### DIFF
--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1608,10 +1608,20 @@ bool isSameExpression(bool macro, const Token *tok1, const Token *tok2, const Se
     if (tok1 == nullptr || tok2 == nullptr)
         return false;
     // An unknown string-prefix macro leaves the literal outside the AST.
-    // Comparing only the macro name would ignore the rest of the expression.
-    if ((!tok1->isKeyword() && Token::Match(tok1, "%name% %str%")) ||
-        (!tok2->isKeyword() && Token::Match(tok2, "%name% %str%")))
-        return false;
+    // Compare the literal text as well so identical literals still compare equal.
+    const bool stringPrefix1 = !tok1->isKeyword() && Token::Match(tok1, "%name% %str%");
+    const bool stringPrefix2 = !tok2->isKeyword() && Token::Match(tok2, "%name% %str%");
+    if (stringPrefix1 || stringPrefix2) {
+        if (!stringPrefix1 || !stringPrefix2)
+            return false;
+        for (const Token* str1 = tok1->next(), *str2 = tok2->next();
+             Token::Match(str1, "%str%") || Token::Match(str2, "%str%");
+             str1 = str1->next(), str2 = str2->next()) {
+            if (!Token::Match(str1, "%str%") || !Token::Match(str2, "%str%") ||
+                str1->str() != str2->str() || !compareTokenFlags(str1, str2, macro))
+                return false;
+        }
+    }
     // tokens needs to be from the same TokenList so no need check standard on both of them
     if (tok1->isCpp()) {
         if (tok1->str() == "." && tok1->astOperand1() && tok1->astOperand1()->str() == "this")

--- a/lib/astutils.cpp
+++ b/lib/astutils.cpp
@@ -1607,6 +1607,11 @@ bool isSameExpression(bool macro, const Token *tok1, const Token *tok2, const Se
         return true;
     if (tok1 == nullptr || tok2 == nullptr)
         return false;
+    // An unknown string-prefix macro leaves the literal outside the AST.
+    // Comparing only the macro name would ignore the rest of the expression.
+    if ((!tok1->isKeyword() && Token::Match(tok1, "%name% %str%")) ||
+        (!tok2->isKeyword() && Token::Match(tok2, "%name% %str%")))
+        return false;
     // tokens needs to be from the same TokenList so no need check standard on both of them
     if (tok1->isCpp()) {
         if (tok1->str() == "." && tok1->astOperand1() && tok1->astOperand1()->str() == "this")

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -202,6 +202,11 @@ private:
         ASSERT_EQUALS(false, isSameExpression("x == PREFIX \"/a\" || x == PREFIX \"/b\";\n", "==", "==", cpp));
         ASSERT_EQUALS(false, isSameExpression("x == PREFIX \"/a\" || x == PREFIX;\n", "==", "==", cpp));
         ASSERT_EQUALS(false, isSameExpression("x == PREFIX || x == PREFIX \"/a\";\n", "==", "==", cpp));
+        ASSERT_EQUALS(true,  isSameExpression("x == PREFIX \"/a\" || x == PREFIX \"/a\";\n", "==", "==", cpp));
+        ASSERT_EQUALS(true,  isSameExpression("x == PREFIX \"/a\" \"/b\" || x == PREFIX \"/a\" \"/b\";\n", "==", "==", cpp));
+        ASSERT_EQUALS(false, isSameExpression("x == PREFIX \"/a\" \"/b\" || x == PREFIX \"/a\" \"/c\";\n", "==", "==", cpp));
+        ASSERT_EQUALS(false, isSameExpression("x == FIRST \"/a\" || x == SECOND \"/a\";\n", "==", "==", cpp));
+        ASSERT_EQUALS(false, isSameExpression("x == PREFIX L\"/a\" || x == PREFIX \"/a\";\n", "==", "==", cpp));
 
         // the remaining test cases are not valid C code
         if (!cpp)

--- a/test/testastutils.cpp
+++ b/test/testastutils.cpp
@@ -198,10 +198,16 @@ private:
         ASSERT_EQUALS(!cpp,  isSameExpression("void f() {double y = 1e1; (x + 10.0) < (y + x); } \n", "+", "+", cpp));
         ASSERT_EQUALS(true,  isSameExpression("void f() {double y = 1e1; double z = 10.0; (x + y) < (x + z); } \n", "+", "+", cpp));
         ASSERT_EQUALS(true,  isSameExpression("A + A\n", "A", "A", cpp));
+        // An unknown string-prefix macro leaves the literal outside the AST. #5738
+        ASSERT_EQUALS(false, isSameExpression("x == PREFIX \"/a\" || x == PREFIX \"/b\";\n", "==", "==", cpp));
+        ASSERT_EQUALS(false, isSameExpression("x == PREFIX \"/a\" || x == PREFIX;\n", "==", "==", cpp));
+        ASSERT_EQUALS(false, isSameExpression("x == PREFIX || x == PREFIX \"/a\";\n", "==", "==", cpp));
 
         // the remaining test cases are not valid C code
         if (!cpp)
             return;
+
+        ASSERT_EQUALS(true, isSameExpression("void f(int x) { x ? throw \"a\" : throw \"a\"; }\n", "throw", "throw", cpp));
 
         //https://trac.cppcheck.net/ticket/9700
         ASSERT_EQUALS(true, isSameExpression("A::B + A::B;\n", "::", "::", cpp));

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -12170,6 +12170,11 @@ private:
               "        : (name.startswith(SRCDIR \"/com/\") || name.startswith(SRCDIR \"/uno/\"));\n"
               "}\n", dinit(CheckOptions, $.inconclusive = false));
         ASSERT_EQUALS("", errout_str());
+
+        check("bool f(StringRef name) {\n"
+              "    return name == SRCDIR \"/a\" || name == SRCDIR \"/a\";\n"
+              "}\n", dinit(CheckOptions, $.inconclusive = false));
+        ASSERT_EQUALS("[test.cpp:2:32]: (style) Same expression on both sides of '||'. [duplicateExpression]\n", errout_str());
     }
 
     void raceAfterInterlockedDecrement() {

--- a/test/testother.cpp
+++ b/test/testother.cpp
@@ -12163,6 +12163,13 @@ private:
               "   return  name.startswith(SRCDIR \"/com/\") || name.startswith(SRCDIR \"/uno/\");\n"
               "};\n", dinit(CheckOptions, $.inconclusive = false));
         ASSERT_EQUALS("", errout_str());
+
+        check("bool isInUnoIncludeFile(StringRef name) {\n"
+              "    return isInMainFile()\n"
+              "        ? (name == SRCDIR \"/cppu/compat.cxx\" || name == SRCDIR \"/sal/compat.cxx\")\n"
+              "        : (name.startswith(SRCDIR \"/com/\") || name.startswith(SRCDIR \"/uno/\"));\n"
+              "}\n", dinit(CheckOptions, $.inconclusive = false));
+        ASSERT_EQUALS("", errout_str());
     }
 
     void raceAfterInterlockedDecrement() {


### PR DESCRIPTION
This fixes the false `duplicateExpression` warning reported in [Trac #5738](https://trac.cppcheck.net/ticket/5738).

I reproduced it with expressions like this:

```cpp
name == SRCDIR "/a" || name == SRCDIR "/b"
```

The `startswith(...)` case from this ticket was fixed in [July 2018](https://github.com/cppcheck-opensource/cppcheck/commit/03faa25d12fac2321996418ce025ad06ecc83665). The direct comparisons above still trigger the warning on current main. This PR addresses those remaining comparisons.

When `SRCDIR` is undefined, Cppcheck compares the macro names and misses the different strings after them. The patch prevents that incomplete comparison from producing a duplicate warning.

I added regression tests for the reported case and checked that real duplicates still produce warnings, including identical `throw` expressions. The three focused tests fail before the fix and pass after it. The full C++ suite passes with 5,323 tests and 355 existing TODOs. These checks ran on Linux/WSL at commit `c976cac0ec531e1ff47b8cf78028f1182e84a35e`.

I found this issue through the bounty page. Is the program still running, and would this fix qualify for the listed $20? I'm based in Türkiye and can also receive crypto. Which payment methods do you support, and roughly how long does payment usually take?

I also have local fixes for [Trac #6552](https://trac.cppcheck.net/ticket/6552) and [Trac #4270](https://trac.cppcheck.net/ticket/4270). How should I request assignment for those?
