### PR TITLE
Fix function pointer typedef simplification (Trac #5935)

### DIFF
--- a/lib/tokenize.cpp
+++ b/lib/tokenize.cpp
@@ -861,7 +861,10 @@ namespace {
             }
 
             if (isFunctionPointer) {
-                if (Token::Match(after, "( * %name% ) ("))
+                // Keep the argument list for a parenthesized pointer declarator: fp *(name).
+                if (after->previous() != tok3 && Token::Match(after->previous(), "* ( %name% ) ;|,|="))
+                    after = after->link()->next();
+                else if (Token::Match(after, "( * %name% ) ("))
                     after = after->link()->linkAt(1)->next();
                 else if (after->str() == "(") {
                     useAfterVarRange = false;

--- a/test/testsimplifytypedef.cpp
+++ b/test/testsimplifytypedef.cpp
@@ -65,6 +65,7 @@ private:
         TEST_CASE(cfp5);
         TEST_CASE(cfp6);
         TEST_CASE(cfp7);
+        TEST_CASE(cfp8);
         TEST_CASE(carray1);
         TEST_CASE(carray2);
         TEST_CASE(carray3);
@@ -520,6 +521,16 @@ private:
                             "uint32_t g();\n"
                             "fp f;\n";
         ASSERT_EQUALS("uint32_t g ( ) ; uint32_t ( * f ) ( uint32_t n ) ;", simplifyTypedef(code));
+    }
+
+    void cfp8() { // #5935
+        const char code[] = "typedef TypeDefStruct *(*ThisIsTheProblem)(Type *Var);\n"
+                            "typedef struct Struct1 {\n"
+                            "  ThisIsTheProblem *(AnotherType);\n"
+                            "} Struct1;\n";
+        const char expected[] = "struct Struct1 { TypeDefStruct * ( * * ( AnotherType ) ) ( Type * Var ) ; } ;";
+        ASSERT_EQUALS(expected, simplifyTypedefC(code));
+        ASSERT_EQUALS(expected, simplifyTypedef(code));
     }
 
     void carray1() {


### PR DESCRIPTION
Fixes [Trac #5935](https://trac.cppcheck.net/ticket/5935).

The function-pointer typedef simplifier treated the opening parenthesis in a use such as `FunctionPointer *(name)` as a function parameter list. That discarded the typedef's actual parameter range and produced an incomplete declaration.

This change recognizes that parenthesized pointer declarator and keeps the function-pointer parameter list. The regression covers both C and C++ simplification.

Validation on Windows with MSVC:

- `TestSimplifyTypedef::cfp8`
- `TestSimplifyTypedef`, `TestTokenize`, `TestSymboldatabase`, `TestVarID`, and `TestTokenizer`: 1,344 tests, 0 failures

This contribution was implemented and tested autonomously by OpenAI Codex under the GitHub account owner's authorization. The account owner handles identity and any payment administration.