### PR TITLE
gnu.cfg: Add all bit operation builtins

### DIFF
--- a/cfg/gnu.cfg
+++ b/cfg/gnu.cfg
@@ -241,16 +241,94 @@
   <function name="__builtin_trap,__builtin_unreachable">
     <noreturn>true</noreturn>
   </function>
+  <!-- https://gcc.gnu.org/onlinedocs/gcc/Bit-Operation-Builtins.html -->
   <!-- int __builtin_popcount (unsigned int x) -->
+  <!-- int __builtin_popcountl (unsigned long x) -->
+  <!-- int __builtin_popcountll (unsigned long long x) -->
   <!-- int __builtin_parity (unsigned int x) -->
+  <!-- int __builtin_parityl (unsigned long x) -->
+  <!-- int __builtin_parityll (unsigned long long x) -->
   <!-- int __builtin_ffs (int x) -->
-  <!-- int __builtin_ffsl (long) -->
-  <!-- int __builtin_ffsll (long long) -->
-  <!-- int __builtin_clz (unsigned int x) -->
-  <function name="__builtin_popcount,__builtin_parity,__builtin_ffs,__builtin_ffsl,__builtin_ffsll,__builtin_clz">
+  <!-- int __builtin_ffsl (long x) -->
+  <!-- int __builtin_ffsll (long long x) -->
+  <!-- int __builtin_clrsb (int x) -->
+  <!-- int __builtin_clrsbl (long x) -->
+  <!-- int __builtin_clrsbll (long long x) -->
+  <function name="__builtin_popcount,__builtin_popcountl,__builtin_popcountll,__builtin_parity,__builtin_parityl,__builtin_parityll,__builtin_ffs,__builtin_ffsl,__builtin_ffsll,__builtin_clrsb,__builtin_clrsbl,__builtin_clrsbll">
     <noreturn>false</noreturn>
     <returnValue type="int"/>
     <use-retval/>
+    <const/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int __builtin_clz (unsigned int x) -->
+  <!-- int __builtin_clzl (unsigned long x) -->
+  <!-- int __builtin_clzll (unsigned long long x) -->
+  <!-- int __builtin_ctz (unsigned int x) -->
+  <!-- int __builtin_ctzl (unsigned long x) -->
+  <!-- int __builtin_ctzll (unsigned long long x) -->
+  <function name="__builtin_clz,__builtin_clzl,__builtin_clzll,__builtin_ctz,__builtin_ctzl,__builtin_ctzll">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <use-retval/>
+    <const/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <not-bool/>
+      <!-- result is undefined if x is 0 -->
+      <valid>1:</valid>
+    </arg>
+  </function>
+  <!-- int __builtin_ffsg (...) -->
+  <!-- int __builtin_clrsbg (...) -->
+  <!-- int __builtin_popcountg (...) -->
+  <!-- int __builtin_parityg (...) -->
+  <function name="__builtin_ffsg,__builtin_clrsbg,__builtin_popcountg,__builtin_parityg">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <use-retval/>
+    <const/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- int __builtin_clzg (...) -->
+  <!-- int __builtin_ctzg (...) -->
+  <function name="__builtin_clzg,__builtin_ctzg">
+    <noreturn>false</noreturn>
+    <returnValue type="int"/>
+    <use-retval/>
+    <const/>
+    <arg nr="1" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+    <arg nr="variadic" direction="in">
+      <not-uninit/>
+      <not-bool/>
+    </arg>
+  </function>
+  <!-- unsigned int __builtin_stdc_bit_width (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_count_ones (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_count_zeros (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_first_leading_one (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_first_leading_zero (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_first_trailing_one (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_first_trailing_zero (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_leading_ones (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_leading_zeros (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_trailing_ones (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_trailing_zeros (uintX_t x) -->
+  <!-- unsigned int __builtin_stdc_has_single_bit (uintX_t x) -->
+  <function name="__builtin_stdc_bit_width,__builtin_stdc_count_ones,__builtin_stdc_count_zeros,__builtin_stdc_first_leading_one,__builtin_stdc_first_leading_zero,__builtin_stdc_first_trailing_one,__builtin_stdc_first_trailing_zero,__builtin_stdc_leading_ones,__builtin_stdc_leading_zeros,__builtin_stdc_trailing_ones,__builtin_stdc_trailing_zeros,__builtin_stdc_has_single_bit">
+    <noreturn>false</noreturn>
+    <returnValue type="unsigned int"/>
+    <use-retval/>
+    <const/>
     <arg nr="1" direction="in">
       <not-uninit/>
       <not-bool/>

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -214,7 +214,7 @@ int invalidFunctionArgBool_ctzg(unsigned int a, unsigned int b) {
     return __builtin_ctzg(a, a % b == 0);
 }
 
-int useRetval_stdc_width(size_t n) {
+int ignoredReturnValue_stdc_width(size_t n) {
     // cppcheck-suppress ignoredReturnValue
     __builtin_stdc_bit_width(n);
     return 0;

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -197,6 +197,29 @@ void knownConditionTrueFalse_ffsll(long long i)
     if (ffsll(i) == 0) {}
 }
 
+int uninitvar_popcount() {
+    unsigned int a;
+    // cppcheck-suppress uninitvar
+    int b = __builtin_popcount(a); // popcount requires init arg
+    return b;
+}
+
+int invalidFunctionArg_clz() {
+    // cppcheck-suppress invalidFunctionArg
+    return __builtin_clz(0);
+}
+
+int invalidFunctionArgBool_ctzg(unsigned int a, unsigned int b) {
+    // cppcheck-suppress invalidFunctionArgBool
+    return __builtin_ctzg(a, a % b == 0);
+}
+
+int useRetval_stdc_width(size_t n) {
+    // cppcheck-suppress ignoredReturnValue
+    __builtin_stdc_bit_width(n);
+    return 0;
+}
+
 #if !defined(__APPLE__)
 int nullPointer_semtimedop(int semid, struct sembuf *sops, size_t nsops, const struct timespec *timeout)
 {

--- a/test/cfg/gnu.c
+++ b/test/cfg/gnu.c
@@ -214,11 +214,13 @@ int invalidFunctionArgBool_ctzg(unsigned int a, unsigned int b) {
     return __builtin_ctzg(a, a % b == 0);
 }
 
+#if __GNUC__ > 14
 int ignoredReturnValue_stdc_width(size_t n) {
     // cppcheck-suppress ignoredReturnValue
     __builtin_stdc_bit_width(n);
     return 0;
 }
+#endif
 
 #if !defined(__APPLE__)
 int nullPointer_semtimedop(int semid, struct sembuf *sops, size_t nsops, const struct timespec *timeout)


### PR DESCRIPTION
I implemented all of the functions described at [https://gcc.gnu.org/onlinedocs/gcc/Built-in-Functions.html](https://gcc.gnu.org/onlinedocs/gcc/Built-in-Functions.html) except for the ones that have a variable return type based on the arguments. This PR should be a superset of the changes proposed in #8721. 

I didn't write any tests because I am not sure what the standard practice is. Should I try to have a test for each <function> tag? I have some tests, but I figured I would ask first.
